### PR TITLE
Pass `@editorView` to every linters, as expected

### DIFF
--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -47,7 +47,7 @@ class LinterView
     for linter in linters
       sytaxType = {}.toString.call(linter.syntax)
       if sytaxType is '[object Array]' && grammarName in linter.syntax or sytaxType is '[object String]' && grammarName is linter.syntax
-        @linters.push(new linter())
+        @linters.push(new linter(@editorView))
 
   handleBufferEvents: () =>
     buffer = @editor.getBuffer()


### PR DESCRIPTION
In your `linter-jshint` you expect to have `editorView` passed to the constructor.

And I need this for my `linter-jscs` to make it works and be abble to release it! :)

See: https://github.com/iam4x/linter-jscs
