### PR TITLE
fix(search.results): fixing execption on search results view

### DIFF
--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -27,8 +27,7 @@ class LinterView
     @initLinters(linters)
 
     atom.workspaceView.on 'pane:active-item-changed', =>
-      @statusBarView.hide()
-      if @editor.id is atom.workspace.getActiveEditor().id
+      if @editor.id is atom.workspace.getActiveEditor()?.id
         @dislayStatusBar()
 
     @handleBufferEvents()


### PR DESCRIPTION
add this error when I was switching to a search results view:

![error](http://i.imgur.com/FhqePcd.png)

It seems that `atom.workspace` is not an editor on this view, can't call `getActiveEditor()`.
