### PR TITLE
Apply a linter if the scope name starts with any of the linter's syntaxes 

### DIFF
--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -41,12 +41,26 @@ class LinterView
 
     @lint()
 
+  getSyntax: (linter) ->
+    sytaxType = {}.toString.call(linter.syntax)
+    if sytaxType is '[object Array]'
+      return linter.syntax
+
+    else if sytaxType is '[object String]'
+      return [linter.syntax]
+
+    return []
+
+  isLinterInScope: (linter, scopeName) ->
+    return true for syntax in @getSyntax linter when scopeName.startsWith syntax
+
+    false
+
   initLinters: (linters) ->
     @linters = []
-    grammarName = @editor.getGrammar().scopeName
+    scopeName = @editor.getGrammar().scopeName
     for linter in linters
-      sytaxType = {}.toString.call(linter.syntax)
-      if sytaxType is '[object Array]' && grammarName in linter.syntax or sytaxType is '[object String]' && grammarName is linter.syntax
+      if @isLinterInScope linter, scopeName
         @linters.push(new linter(@editor))
 
   handleBufferEvents: () =>


### PR DESCRIPTION
I have a package that modifies the scope name for certain python files to be `source.python.django.models` or `source.python.django.forms`.  

Instead of listing all possible scope names in the linter's syntax, I believe it would be better to check if the scopeName starts with the given syntax, in this case `source.python`.

Also created and published [linter-pep8](https://atom.io/packages/linter-pep8) and [linter-pyflakes](https://atom.io/packages/linter-pyflakes).  If you want to bring these under the `AtomLinter` umbrella, let me know.
