### PR TITLE
Add ability to dicover linters that are not named linter-{name}

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -12,10 +12,10 @@ module.exports =
     @linterViews = []
 
     @linters = []
-    for atomPackage in atom.packages.getAvailablePackageNames()
-      if atomPackage.match(/^linter-/)
-        if atom.packages.getLoadedPackage(atomPackage).metadata['linter-package'] is true
-          @linters.push(require "#{atom.packages.getLoadedPackage(atomPackage).path}/lib/#{atomPackage}")
+    for atomPackage in atom.packages.getLoadedPackages()
+      if atomPackage.metadata['linter-package'] is true
+        implemention = atomPackage.metadata['linter-implementation'] ? atomPackage.name
+        @linters.push(require "#{atomPackage.path}/lib/#{implemention}")
 
     @enabled = true
     @statusBarView = new StatusBarView()


### PR DESCRIPTION
Use get loaded packages to find all loaded linters via just metadata.  Enable's non linter packages to utilize linter functionality to create linter style views. 

Should also resolve issue #15 allowing users to disable linters without uninstalling.
