### PR TITLE
fix issue where temp file can be closed before all linters have run

### DIFF
--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -112,22 +112,22 @@ class LinterView
     @gutterView.clear()
     if @linters.length > 0
       temp.open {suffix: @editor.getGrammar().scopeName}, (err, info) =>
-        @tempFile = info.path
+        info.completedLinters = 0
         fs.write info.fd, @editor.getText(), =>
           fs.close info.fd, (err) =>
             for linter in @linters
-              linter.lintFile(info.path, @processMessage)
+              linter.lintFile(info.path, (messages) => @processMessage(messages, info))
 
   # Internal: Process the messages returned by linters and render them.
   #
   # messages - An array of messages to annotate:
   #           :level  - the annotation error level ('error', 'warning')
   #           :range - The buffer range that the annotation should be placed
-  processMessage: (messages) =>
-    @totalProcessed++
+  processMessage: (messages, tempFileInfo) =>
+    tempFileInfo.completedLinters++
     @messages = @messages.concat(messages)
-    if @totalProcessed == @linters.length
-      fs.unlink @tempFile
+    if tempFileInfo.completedLinters == @linters.length
+      fs.unlink tempFileInfo.path
     @display()
 
   # Internal: Render all the linter messages


### PR DESCRIPTION
Fix for #13, I was noticing this on and off over the weekend when making quick changes in large files. The linter would close the file reference before it was done with the file.  

I had an thought this morning that it might be that when we trigger multiple lint attempts in succession we lose the reference to the correct `@tempFile`. 

This has the added issue of not unlinking all temp files we create and I found this morning that I had like 40 megs of tempfiles created by the linter but not unlinked until I restarted the editor.
