### PR TITLE
Implemented the `linter-cpplint` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The idea is to stop the linter plugins war, by providing a top level API for lin
 - [linter-xmllint](https://atom.io/packages/linter-xmllint), for XML, using `xmllint`
 - [linter-shellcheck](https://atom.io/packages/linter-shellcheck), for Bash, using `shellcheck`.
 - [linter-scalac](https://atom.io/packages/linter-scalac), for Scala, using `scalac`.
+- [linter-cpplint](https://atom.io/packages/linter-cpplint), for C++, using `cpplint`.
 
 ## Features
 


### PR DESCRIPTION
I've created the `linter-cpplint` package:

https://github.com/Nathan-Smith/linter-cpplint
https://atom.io/packages/linter-cpplint

It runs the [Google Style Guild C++ Linter](http://google-styleguide.googlecode.com/svn/trunk/cpplint/cpplint.py) which mostly follows the [Google Style Guide](http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml)
