### PR TITLE
fix(config): config name should be camel case

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -12,8 +12,8 @@ class LinterInitializer
     showHightlighting: true
     showGutters: true
     showMessagesAroundCursor: true
-    'Lint on modify debounce interval (in ms)': 1000
-    'Show Status Bar when cursor is in error range': false
+    lintOnModifyDebounceInterval: 1000
+    showStatusBarWhenCursorIsInErrorRange: false
 
   # Public: Activate the plugin setting up StatusBarView and dicovering linters
   activate: ->

--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -70,7 +70,7 @@ class LinterView
     @subscriptions.push atom.config.observe 'linter.lintOnSave',
       (lintOnSave) => @lintOnSave = lintOnSave
 
-    @subscriptions.push atom.config.observe 'linter.Lint on modify debounce interval (in ms)',
+    @subscriptions.push atom.config.observe 'linter.lintOnModifyDebounceInterval',
       (lintOnModifiedDelayMS) =>
         # If text instead of number into user config
         debounceInterval = parseInt(lintOnModifiedDelayMS)

--- a/lib/statusbar-view.coffee
+++ b/lib/statusbar-view.coffee
@@ -13,7 +13,7 @@ class StatusBarView extends View
 
     # Config value if you want to limit the status bar report
     # if your cursor is in the range or error, or on the line
-    limitOnErrorRange = atom.config.get 'linter.Show Status Bar when cursor is in error range'
+    limitOnErrorRange = atom.config.get 'linter.showStatusBarWhenCursorIsInErrorRange'
 
     # Hide the last version of this view
     @hide()


### PR DESCRIPTION
When you `observe` a config value, it will be added into the `atom.config` and it not seems to be a good behavior to have not camel case config name.

![screen shot 2014-05-30 at 3 21 15 pm](https://cloud.githubusercontent.com/assets/893837/3130914/89d62478-e7fe-11e3-8944-e8efb58cdd11.png)

The issue #64 is affiliated I think.
