### PR TITLE
Clean console log

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -32,7 +32,6 @@ class LinterInitializer
     @editorViewSubscription = atom.workspaceView.eachEditorView (editorView) =>
       linterView = @injectLinterViewIntoEditorView(editorView, @statusBarView)
       editorView.editor.on 'grammar-changed', =>
-        console.log 'linter: grammar changed'
         linterView.initLinters(@linters)
         linterView.lint()
         @linterViews.push(linterView)
@@ -42,8 +41,7 @@ class LinterInitializer
     return unless editorView.getPane()?
     return unless editorView.attached
     return if editorView.linterView?
-    console.log "editorView.editor.getGrammar().scopeName" +
-      editorView.editor.getGrammar().scopeName
+
     linterView = new LinterView(editorView, statusBarView, @linters)
     linterView
 

--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -112,7 +112,6 @@ class LinterView
 
   # Public: lint the current file in the editor using the live buffer
   lint: ->
-    console.log 'linter: run commands'
     @totalProcessed = 0
     @messages = []
     @gutterView.clear()

--- a/lib/linter.coffee
+++ b/lib/linter.coffee
@@ -74,13 +74,9 @@ class Linter
   #
   # Override this if you don't intend to use base command execution logic
   lintFile: (filePath, callback) ->
-    console.log 'linter: run linter command'
-    console.log @getCmd(filePath)
-    console.log @cwd
     exec @getCmd(filePath), {cwd: @cwd}, (error, stdout, stderr) =>
       if stderr
-        console.log stderr
-      console.log stdout
+        console.warn stderr
       if @errorStream == 'stdout'
         @processMessage(stdout, callback)
       else if @errorStream == 'stderr'
@@ -95,7 +91,6 @@ class Linter
     messages = []
     regex = XRegExp @regex, @regexFlags
     XRegExp.forEach message, regex, (match, i) =>
-      console.log match
       messages.push(@createMessage(match))
     , this
     callback messages


### PR DESCRIPTION
Hi @hd-deman and @park9140,

I think we should clean every `console.log` and use the only when we are working on the code. I don't like to have my code polluted with logs in 'production'

Do you agree guys? Can I delete all these `console.log` :D ?

We can also have an "intern" console.log, and de-activate it if `atom.inDevMode()` is false.
