### PR TITLE
Throttle instead debounce

### DIFF
--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -76,7 +76,7 @@ class LinterView
         debounceInterval = parseInt(lintOnModifiedDelayMS)
         debounceInterval = 1000 if isNaN debounceInterval
         # create debounced lint command
-        @debouncedLint = (_.debounce @lint, debounceInterval).bind this
+        @debouncedLint = (_.throttle @lint, debounceInterval).bind this
 
     @subscriptions.push atom.config.observe 'linter.lintOnModified',
       (lintOnModified) => @lintOnModified = lintOnModified


### PR DESCRIPTION
Change `_.debounce` to `_.throttle` it makes more sense I think, because I want to lint the first time the user starts to type, and then every X seconds if he doesn't stop typing. Instead of waiting the user stops typing.
