### PR TITLE
fix(status.bar): remove status bar on file close

### DIFF
--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -35,6 +35,9 @@ class LinterView
 
     @initLinters(linters)
 
+    @subscriptions.push atom.workspaceView.on 'pane:item-removed', =>
+      @statusBarView.hide()
+
     @subscriptions.push atom.workspaceView.on 'pane:active-item-changed', =>
       @statusBarView.hide()
       if @editor.id is atom.workspace.getActiveEditor()?.id


### PR DESCRIPTION
Fix a bug when close the current file with status bar shown, the status bar with error will still be shown until you open a new file.
