### PR TITLE
Move packages `chai` and `sinon` to `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,12 @@
     "lodash": "^2.4.1",
     "shelljs": "^0.2.6",
     "temp": "~0.8.0",
-    "xregexp": "2.0.0"
+    "xregexp": "2.0.0",
+    "chai": "^1.9.1",
+    "sinon": "^1.10.0"
   },
   "devDependencies": {
     "biscotto": "^2.1.1",
-    "chai": "^1.9.1",
     "grunt": "^0.4.5",
     "grunt-coffeelint": "^0.0.10",
     "grunt-contrib-clean": "^0.5.0",
@@ -34,7 +35,6 @@
     "grunt-lesslint": "^1.1.3",
     "grunt-lintspaces": "^0.5.1",
     "load-grunt-tasks": "^0.4.0",
-    "pygments": "^0.2.0",
-    "sinon": "^1.10.0"
+    "pygments": "^0.2.0"
   }
 }


### PR DESCRIPTION
`chai` and `sinon`  were listed in `devDependencies`, but they are not required for developing, they are required for testing. A normal user wouldn't install them and running the package tests would fail:
`Error: Cannot find module 'sinon'`
`Error: Cannot find module 'chai'`
