### PR TITLE
Change gutter warnings/errors to color the line numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "copy-paste": "^0.2.2",
     "emissary": "^1.0.0",
-    "font-awesome": "4.0.3",
     "jshint": "^2.4.4",
     "lodash": "^2.4.1",
     "shelljs": "^0.2.6",

--- a/stylesheets/linter.less
+++ b/stylesheets/linter.less
@@ -4,35 +4,14 @@
 // for a full listing of what's available.
 // @import 'ui-variables';
 
-@import '../node_modules/font-awesome/less/variables';
-@fa-font-path: "https://netdna.bootstrapcdn.com/font-awesome/4.0.3/fonts"; // for referencing Bootstrap CDN font files directly
-@import '../node_modules/font-awesome/less/path';
-
 @error-color: #b22222;
 @warning-color: #DAA520;
 
-.line-number:before {
-  visibility: hidden;
-  position: relative;
-  bottom: .19em;
-  margin-right: .6em;
-  content: "\f111";
-  font-size:  0.7em;
-  display: inline-block;
-  font-family: FontAwesome;
-  font-style: normal;
-  font-weight: normal;
-  -webkit-font-smoothing: antialiased;
-}
-
-.linter-warning:before {
-  visibility: visible !important;
+.linter-warning {
   color: @warning-color;
-
 }
 
-.linter-error:before {
-  visibility: visible !important;
+.linter-error {
   color: @error-color;
 }
 


### PR DESCRIPTION
Changes the warnings/errors in the gutter so instead of additional dots being shown next to the line numbers, the line numbers themselves are colored. I think this has several advantages:
- Integrates more nicely with atom.io, for example the folding feature of atom uses something similar
- Makes the gutter smaller, leaving more room for content
- Less intrusive while working, still easily spottable when needed
- Removes font-awesome dependency

Example:

![screen shot 2014-06-12 at 11 13 01](https://cloud.githubusercontent.com/assets/229105/3255980/eea6009a-f211-11e3-8834-0782aa4fa51b.png)

PS: This is my first pull request, be patient if something is not as it should please ;-)
