### PR TITLE
Use project path as cwd if present

### DIFF
--- a/lib/linter.coffee
+++ b/lib/linter.coffee
@@ -45,7 +45,7 @@ class Linter
 
   # Public: Construct a linter passing it's base editor
   constructor: (@editor) ->
-    @cwd = path.dirname(editor.getUri())
+    @cwd = atom.project.path ? path.dirname(editor.getUri())
 
   # Private: get command and args for atom.BufferedProcess for execution
   getCmdAndArgs: (filePath) ->


### PR DESCRIPTION
See https://github.com/AtomLinter/linter-pylint/pull/8 for motivation for this.
It's helpful to use the project root for Python linting at least. I suspect it
would be useful more generally too.

Feel free to close this request if you disagree.

Test Plan:
Crossed fingers
