### PR TITLE
Allow Linters to specify command as an array

### DIFF
--- a/lib/linter.coffee
+++ b/lib/linter.coffee
@@ -50,8 +50,10 @@ class Linter
   getCmdAndArgs: (filePath) ->
     cmd = @cmd
 
-    # here guarantee `cmd` does not have space or quote mark issue
-    cmd_list = cmd.split(' ').concat [filePath]
+    if not Array.isArray(cmd)
+      cmd_list = cmd.split(' ').concat [filePath]
+    else
+      cmd_list = cmd.concat [filePath]
 
     if @executablePath
       cmd_list[0] = path.join @executablePath, cmd_list[0]

--- a/spec/linter-spec.coffee
+++ b/spec/linter-spec.coffee
@@ -105,3 +105,31 @@ describe "Linter:lintFile", ->
     waitsFor ->
       flag
     , "lint file finished"
+
+  it "lints when command is an array", ->
+    flag = false
+
+    runs ->
+      linter.cmd = ['cat']
+      linter.lintFile "fixture/messages.txt", (messages) ->
+        console.log messages
+        expect(messages.length).toBe(2)
+        flag = true
+
+    waitsFor ->
+      flag
+    , "lint file finished"
+
+  it "lints when command is an array with arguments containing spaces", ->
+    flag = false
+
+    runs ->
+      linter.cmd = ['cat', 'fixture/messages with space.txt']
+      linter.lintFile "fixture/messages.txt", (messages) ->
+        console.log messages
+        expect(messages.length).toBe(4)
+        flag = true
+
+    waitsFor ->
+      flag
+    , "lint file finished"


### PR DESCRIPTION
This is half of a fix to https://github.com/AtomLinter/Linter/issues/116

With this change Linters can set their command to an array instead of letting Linter split the command for them, which messes up any arguments with spaces.
