### PR TITLE
Add keybinding to trigger linting manually

### DIFF
--- a/keymaps/linter.cson
+++ b/keymaps/linter.cson
@@ -1,0 +1,2 @@
+'.editor:not(.mini)':
+  'ctrl-cmd-l': 'linter:lint'

--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -118,6 +118,8 @@ class LinterView
       if @editor.id is atom.workspace.getActiveEditor()?.id
         @throttledLint() if @lintOnEditorFocus
 
+    atom.workspaceView.command "linter:lint", => @lint()
+
   # Public: lint the current file in the editor using the live buffer
   lint: ->
     @totalProcessed = 0


### PR DESCRIPTION
Default keybinding copied from the Sublime Text linter.

Fixes #146.

Test Plan:
- Opened Atom, turned off lint on focus/modify/save
- Reloaded the window and edited code so that there was a lint error
- Pressed `cmd-ctrl-l` and saw a lint error appear
- Fixed the lint error and pressed the bind again
- Lint error now gone
