### PR TITLE
Fix for multiple linters on the same file (#139)

### DIFF
--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -130,15 +130,19 @@ class LinterView
         fs.write info.fd, @editor.getText(), =>
           fs.close info.fd, (err) =>
             for linter in @linters
-              linter.lintFile(info.path, (messages) => @processMessage(messages, info))
+              linterInfo =
+                completed: false
+              linter.lintFile(info.path, (messages) => @processMessage(messages, info, linterInfo))
 
   # Internal: Process the messages returned by linters and render them.
   #
   # messages - An array of messages to annotate:
   #           :level  - the annotation error level ('error', 'warning')
   #           :range - The buffer range that the annotation should be placed
-  processMessage: (messages, tempFileInfo) =>
-    tempFileInfo.completedLinters++
+  processMessage: (messages, tempFileInfo, linterInfo) =>
+    if !linterInfo.completed
+      linterInfo.completed = true;
+      tempFileInfo.completedLinters++
     @messages = @messages.concat(messages)
     if tempFileInfo.completedLinters == @linters.length
       fs.unlink tempFileInfo.path


### PR DESCRIPTION
When multiple linters are run on the same file, the file is sometimes unlinked too early when the first linter running emits multiple messages.
A ref-count was added to keep track of how many linters have been processed, and only if all linters have emitted messages, the temporary file is removed (unlinked)
#139
