### PR TITLE
fix linter-erb package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The idea is to stop the linter plugins war, by providing a top level API for lin
 - [linter-clojure](https://atom.io/packages/linter-clojure), for Clojure, using `clojure`
 - [linter-puppet-lint](https://atom.io/packages/linter-puppet-lint), for Puppet, using `puppet-lint`
 - [linter-js-yaml](https://atom.io/packages/linter-js-yaml), for Yaml, using `js-yaml`
-- [linter-ruby-erb](https://atom.io/packages/linter-ruby-erb), for .erb files, using `erb -x`
+- [linter-erb](https://atom.io/packages/linter-erb), for .erb files, using `erb -x`
 
 ## Features
 


### PR DESCRIPTION
Rename package linter-ruby-erb to linter-erb.
