### PR TITLE
fix node path resolution

### DIFF
--- a/lib/linter.coffee
+++ b/lib/linter.coffee
@@ -80,9 +80,9 @@ class Linter
   # Private: Provide the node executable path for use when executing a node
   #          linter
   getNodeExecutablePath: ->
-    path.join require.resolve('package'),
-      '..',
-      'apm/node_modules/atom-package-manager/bin/node'
+    path.join atom.packages.apmPath,
+      '..'
+      'node'
 
   # Public: Primary entry point for a linter, executes the linter then calls
   #         processMessage in order to handle standard output


### PR DESCRIPTION
Partial fix for a part of `spawn ENOENT` problems (#119) caused by Linter not reliably finding the path to `node` executable in `getNodeExecutablePath`.
