### PR TITLE
Add possibility to log all lint erros if the user use the shortcut

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -12,6 +12,7 @@ class LinterInitializer
     showHighlighting: true
     showGutters: true
     showErrorInStatusBar: true
+    displayAllErrors: false
     lintOnChangeInterval: 1000
     showStatusBarWhenCursorIsInErrorRange: false
     lintDebug: false

--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -108,10 +108,10 @@ class LinterView
       if @editor.id is atom.workspace.getActiveEditor()?.id
         @throttledLint() if @lintOnEditorFocus
 
-    atom.workspaceView.command "linter:lint", => @lint(true)
+    atom.workspaceView.command "linter:lint", => @lint()
 
   # Public: lint the current file in the editor using the live buffer
-  lint: (displayAll) ->
+  lint: ->
     @totalProcessed = 0
     @messages = []
     @destroyMarkers()
@@ -121,14 +121,14 @@ class LinterView
         fs.write info.fd, @editor.getText(), =>
           fs.close info.fd, (err) =>
             for linter in @linters
-              linter.lintFile(info.path, (messages) => @processMessage(messages, info, linter, displayAll))
+              linter.lintFile(info.path, (messages) => @processMessage(messages, info, linter))
 
   # Internal: Process the messages returned by linters and render them.
   #
   # messages - An array of messages to annotate:
   #           :level  - the annotation error level ('error', 'warning')
   #           :range - The buffer range that the annotation should be placed
-  processMessage: (messages, tempFileInfo, linter, displayAll) =>
+  processMessage: (messages, tempFileInfo, linter) =>
     log "linter returned", linter, messages
 
     tempFileInfo.completedLinters++
@@ -136,7 +136,7 @@ class LinterView
       fs.unlink tempFileInfo.path
 
     @messages = @messages.concat(messages)
-    @display(displayAll)
+    @display()
 
   # Internal: Destroy all markers (and associated decorations)
   destroyMarkers: ->
@@ -145,7 +145,7 @@ class LinterView
     @markers = null
 
   # Internal: Render all the linter messages
-  display: (displayAll) ->
+  display: ->
     @destroyMarkers()
 
     if @showGutters and not @guttersShowing
@@ -172,14 +172,14 @@ class LinterView
       if @showHighlighting
         @editor.decorateMarker marker, type: 'highlight', class: klass
 
-    @displayStatusBar(displayAll)
+    @displayStatusBar()
 
   # Internal: Update the status bar for new messages
-  displayStatusBar: (displayAll) ->
+  displayStatusBar: ->
     if @showMessagesAroundCursor
-      @statusBarView.render @messages, @editor, displayAll
+      @statusBarView.render @messages, @editor
     else
-      @statusBarView.render [], @editor, displayAll
+      @statusBarView.render [], @editor
 
   # Public: remove this view and unregister all it's subscriptions
   remove: ->

--- a/lib/statusbar-view.coffee
+++ b/lib/statusbar-view.coffee
@@ -22,7 +22,7 @@ class StatusBarView extends View
       stringPos = arguments[0].currentTarget.innerText.split('line: ')
       stringPos = _.findLast(stringPos).split(' / col: ')
       line = parseInt(stringPos[0], 10)
-      col = if stringPos.length > 0 then parseInt(stringPos[1], 10) else 0
+      col = if stringPos[1] then parseInt(stringPos[1], 10) else 0
       @goToLine(line, col)
 
   goToLine: (line, col) ->
@@ -36,7 +36,7 @@ class StatusBarView extends View
     @find('.error-message').off()
     super
 
-  computeMessages: (messages, position, currentLine, displayAll, limitOnErrorRange) ->
+  computeMessages: (messages, position, currentLine, displayAllErrors, limitOnErrorRange) ->
     # Clear `violations` div
     @violations.empty()
 
@@ -48,7 +48,7 @@ class StatusBarView extends View
       showOnline = (item.range?.start.row + 1) is currentLine and not limitOnErrorRange
 
       # If one of the conditions is true, let's show the StatusBar
-      if showInRange or showOnline or displayAll
+      if showInRange or showOnline or displayAllErrors
         pos = "line: #{item.line}"
         if item.col? then pos = "#{pos} / col: #{item.col}"
         violation =
@@ -70,13 +70,15 @@ class StatusBarView extends View
         @show()
 
   # Render the view
-  render: (messages, paneItem, displayAll) ->
+  render: (messages, paneItem) ->
     # preppend this view the bottom
     atom.workspaceView.prependToBottom this
 
     # Config value if you want to limit the status bar report
     # if your cursor is in the range or error, or on the line
     limitOnErrorRange = atom.config.get 'linter.showStatusBarWhenCursorIsInErrorRange'
+    # Display all errors in the file if it set to true
+    displayAllErrors = atom.config.get 'linter.displayAllErrors'
 
     # Hide the last version of this view
     @hide()
@@ -94,6 +96,6 @@ class StatusBarView extends View
     catch e
       error = e
 
-    @computeMessages messages, position, currentLine, displayAll, limitOnErrorRange unless error
+    @computeMessages messages, position, currentLine, displayAllErrors, limitOnErrorRange unless error
 
 module.exports = StatusBarView


### PR DESCRIPTION
I find it useful to have the possibility to display all errors and click on the error to go to the correct line/col.

I implement this feature and it works only when you are using the linter shortcut (because I also want to keep the old behavior).

![atomlinter](https://cloud.githubusercontent.com/assets/1850538/3978589/c5444108-2849-11e4-8b64-5508f24c61a6.gif)

I would like to know if you find this feature useful.

If so, I still have some works to do on this PR:
- Adding specs
- I don't like the way how I get the line number/col of the error. Need to think about a better solution.
