### PR TITLE
Add Haskell Linter to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ The idea is to stop the linter plugins war, by providing a top level API for lin
 - [linter-phpcs](https://atom.io/packages/linter-phpcs), for PHP, using `phpc`
 - [linter-phpmd](https://atom.io/packages/linter-phpmd), for PHP, using `phpmd`
 - [linter-pylint](https://atom.io/packages/linter-pylint), for Python, using `pylint`
-- [linter-pyflakes](https://atom.io/packages/linter-pyflakes), for python, using `pyflakes`
-- [linter-pep8](https://atom.io/packages/linter-pep8), for python, using `pep8`.
-- [linter-flake8](https://atom.io/packages/linter-flake8), for python, using `flake8`
+- [linter-pyflakes](https://atom.io/packages/linter-pyflakes), for Python, using `pyflakes`
+- [linter-pep8](https://atom.io/packages/linter-pep8), for Python, using `pep8`.
+- [linter-flake8](https://atom.io/packages/linter-flake8), for Python, using `flake8`
 - [linter-javac](https://atom.io/packages/linter-javac), for Java, using `javac`
 - [linter-jshint](https://atom.io/packages/linter-jshint), for JavaScript and JSON, using `jshint`
 - [linter-jscs](https://atom.io/packages/linter-jscs), for JavaScript, using `jscs`
@@ -29,12 +29,13 @@ The idea is to stop the linter plugins war, by providing a top level API for lin
 - [linter-shellcheck](https://atom.io/packages/linter-shellcheck), for Bash, using `shellcheck`
 - [linter-scalac](https://atom.io/packages/linter-scalac), for Scala, using `scalac`
 - [linter-clang](https://atom.io/packages/linter-clang), for C / C++, using `clang`
-- [linter-ruby](https://atom.io/packages/linter-ruby), for ruby, using `ruby -wc`
+- [linter-ruby](https://atom.io/packages/linter-ruby), for Ruby, using `ruby -wc`
 - [linter-lua](https://atom.io/packages/linter-lua), for Lua, using `luac -p`
 - [linter-clojure](https://atom.io/packages/linter-clojure), for Clojure, using `clojure`
 - [linter-puppet-lint](https://atom.io/packages/linter-puppet-lint), for Puppet, using `puppet-lint`
 - [linter-js-yaml](https://atom.io/packages/linter-js-yaml), for Yaml, using `js-yaml`
 - [linter-erb](https://atom.io/packages/linter-erb), for .erb files, using `erb -x`
+- [linter-hlint](https://atom.io/packages/linter-hlint), for Haskell files, using `hlint`
 
 ## Features
 


### PR DESCRIPTION
And capitalized Python and Ruby in the cases it wasn't
