### PR TITLE
Set temp file extension to source file extension

### DIFF
--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -116,7 +116,15 @@ class LinterView
     @messages = []
     @destroyMarkers()
     if @linters.length > 0
-      temp.open {suffix: @editor.getGrammar().scopeName}, (err, info) =>
+      
+      # get file extension
+      ext_list = @editor.getBuffer().file.path.split "."
+      if ext_list.length == 1 || (ext_list[0] == "" && ext_list.length == 2)
+          ext = @editor.getGrammar().scopeName
+      else
+          ext = "." + ext_list.pop()
+
+      temp.open {suffix: ext}, (err, info) =>
         info.completedLinters = 0
         fs.write info.fd, @editor.getText(), =>
           fs.close info.fd, (err) =>


### PR DESCRIPTION
Unless an extension can't be extracted, in which case the current usage of grammar name for file extension will be used.  Basically, I ran in to an issue with a linter not being happy unless the extensions matched with the expected filetype.
