### PR TITLE
Added debug log for process timeout

### DIFF
--- a/lib/linter.coffee
+++ b/lib/linter.coffee
@@ -132,6 +132,7 @@ class Linter
     # Don't block UI more than 5seconds, it's really annoying on big files
     setTimeout ->
       process.kill()
+      log 'process timed out'
     , 5000
 
   # Private: process the string result of a linter execution using the regex


### PR DESCRIPTION
I added this because I otherwise had no idea why a particular linter was not returning on a large file.

This is a simple change, but would have proven beneficial to my own debugging.
