### PR TITLE
Fix issue links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,83 +1,64 @@
 # v0.7.1
 
 ### Bug fixes
-* Fix ENOTEMPTY error (See [#218][218])
-* Minor tweaks to inline view (See [#215][215])
-
-[215]: https://github.com/AtomLinter/Linter/pull/215
-[218]: https://github.com/AtomLinter/Linter/issue/218
+* Fix ENOTEMPTY error (See #218)
+* Minor tweaks to inline view (See #215)
 
 # v0.7.0
 
 ### New features
-* Option to display linter messages inline with code (See [#195][195])
+* Option to display linter messages inline with code (#195)
 
 ### Bug fixes
-* Clean up temporary directories (See [#212][212])
-
-[195]: https://github.com/AtomLinter/Linter/pull/195
-[212]: https://github.com/AtomLinter/Linter/issue/212
+* Clean up temporary directories (See #212)
 
 # v0.6.1
 
 ### Bug fixes
 * Fix keyboard shortcuts not working on lines containing lint messages
-  (See [#84][84], [#194][194])
-
-[84]: https://github.com/AtomLinter/Linter/issues/84
-[194]: https://github.com/AtomLinter/Linter/issues/194
+  (See #84, #194)
 
 # v0.6.0
 
 ### New features
-* Option to always show all messages in status bar (See [#196][196])
+* Option to always show all messages in status bar (See #196)
 
 ### New linters
 * htmlhint, pylama, squirrel, CoDscript
 
-[196]: https://github.com/AtomLinter/Linter/pull/196
-
 # v0.5.18
 
 ### Bug Fixes
-* Compatibility with [git-diff][gitdiff] (See [#121][121], [#202][202])
+* Compatibility with [git-diff][gitdiff] (See #121, #202)
 
-[121]: https://github.com/AtomLinter/Linter/issues/121
-[202]: https://github.com/AtomLinter/Linter/issues/202
 [gitdiff]: https://atom.io/packages/git-diff
 
 # v0.5.17
 
 ### Bug Fixes
-* Fix regression for multiple linters in one file (See [#193][193],
-  [#194][194])
-
-[193]: https://github.com/AtomLinter/Linter/issues/193
-[194]: https://github.com/AtomLinter/Linter/pull/194
+* Fix regression for multiple linters in one file (See #193, #194)
 
 # v0.5.16
 
 ### Bug Fixes
-* Better compatibility with `rubocop` and `GHC-mod` (See [#192][192],
+* Better compatibility with `rubocop` and `GHC-mod` (See #192,
   [AtomLinter/rubocop#2][rubocop2])
 
-[192]: https://github.com/AtomLinter/Linter/issues/192
 [rubocop2]: https://github.com/AtomLinter/linter-rubocop/issues/2
 
 # v0.5.15
 
 ### New Features
 * Allow `executablePath` to be a path to an actual executable. Fixes some
-  `spawn ENOTDIR` errors (See [#190][190], [#102][102], [#95][95])
+  `spawn ENOTDIR` errors (See #190, [#102][102], [#95][95])
 
 [95]: https://github.com/AtomLinter/Linter/issues/95#issuecomment-50035054
 [102]: https://github.com/AtomLinter/Linter/issues/102#issuecomment-47029312
-[190]: https://github.com/AtomLinter/Linter/issues/190
 
 # v0.5.14
 
 ### Bug Fixes
-* Fix `spawn ENOENT` errors in projects that have `package.json` files (See [#119](https://github.com/AtomLinter/Linter/issues/119), [#179](https://github.com/AtomLinter/Linter/pull/179))
+* Fix `spawn ENOENT` errors in projects that have `package.json` files (See #119, #179)
 
 # v0.5.12
 
@@ -101,14 +82,14 @@
 # v0.5.7
 
 ### Bug Fixes
-* Fix linters not working on Windows ([#148](https://github.com/AtomLinter/linter/pull/148), [#112](https://github.com/AtomLinter/linter/issue/112))
-* Also fix [#157](https://github.com/AtomLinter/linter/issues/157])
+* Fix linters not working on Windows (#148, #112)
+* Also fix #157)
 
 
 # v0.5.6
 
 ### Bug Fixes
-* Resolve too many linter warnings cover screen bug ([##132](https://github.com/AtomLinter/Linter/issues/132]))
+* Resolve too many linter warnings cover screen bug (#132)
 
 # v0.5.3
 
@@ -118,13 +99,13 @@
 # v0.5.2
 
 ### Bug Fixes
-* Only widen the gutter when showGutter is enabled ([#137](https://github.com/AtomLinter/Linter/issues/137))
-* Delete some unused imports ([#154](https://github.com/AtomLinter/Linter/issues/154))
+* Only widen the gutter when showGutter is enabled (#137)
+* Delete some unused imports (#154)
 
 # v0.5.1
 
 ### New Features
-* Add keybinding to trigger linting manually ([#146](https://github.com/AtomLinter/Linter/issues/146))
+* Add keybinding to trigger linting manually (#146)
 
 # v0.5.0
 
@@ -133,18 +114,18 @@
 * fix typo [(showHightlighting -> showHighlighting)](https://github.com/AtomLinter/Linter/commit/e06ad53bca201b108d5743b7966f8fad5050c74b)
 
 ### New Features
-* Add `@formatMessage` to help any linter to customize message. ([#120](https://github.com/AtomLinter/Linter/pull/120))
-* Use decorations API to display gutter markers ([#147](https://github.com/AtomLinter/Linter/pull/147))
-* Better way to assemble path ([#142]https://github.com/AtomLinter/Linter/pull/142)
+* Add `@formatMessage` to help any linter to customize message. (#120)
+* Use decorations API to display gutter markers (#147)
+* Better way to assemble path (#142)
 
 # v0.4.11
 
 ### Bug Fixes
 
-* Fix `getBufferPosition` bug ([#99](https://github.com/AtomLinter/Linter/issues/99))
+* Fix `getBufferPosition` bug (#99)
 * Don't block UI more than 5s
 * Fix bug when running specs
-* Fix bug when full line error ([#103](https://github.com/AtomLinter/Linter/pull/103))
+* Fix bug when full line error (#103)
 
 # v0.4.10
 ---------
@@ -152,7 +133,7 @@
 ### Bug Fixes
 
 * Fix bug when linter provides 0 length range
-* Fix a bug when special characters appeared in command ([#81](https://github.com/AtomLinter/Linter/pull/81))
+* Fix a bug when special characters appeared in command (#81)
 * Update `temp` package
 
 # v0.4.9
@@ -160,14 +141,14 @@
 
 ### New Features
 * Show error line and column if available in the status bar
-* Lint on focus ([#77](https://github.com/AtomLinter/Linter/pull/77))
-* Clicking error message copies it to clipboard ([#78](https://github.com/AtomLinter/Linter/issues/78))
+* Lint on focus (#77)
+* Clicking error message copies it to clipboard (#78)
 
 ### Bug Fixes
-* Fix the error range construction and line reporting for line zero errors ([#35](https://github.com/AtomLinter/Linter/issues/35))
-* Fix modify interval config ([#64](https://github.com/AtomLinter/Linter/issues/64))
-* Close status bar on file close ([#74](https://github.com/AtomLinter/Linter/pull/74))
-* Fix double error reporting in status bar ([#79](https://github.com/AtomLinter/Linter/pull/79))
+* Fix the error range construction and line reporting for line zero errors (#35)
+* Fix modify interval config (#64)
+* Close status bar on file close (#74)
+* Fix double error reporting in status bar (#79)
 
 ### New Linters
 * [linter-scalac](https://atom.io/packages/linter-scalac), for Scala, using `scalac`
@@ -177,12 +158,12 @@
 -----------------------
 
 ### Bug Fixes
-* Lint on save wasn't triggered with save menu shortcut ([#40](https://github.com/AtomLinter/Linter/issues/40))
-* Not displaying results if cursor on EOF ([#50](https://github.com/AtomLinter/Linter/issues/50))
+* Lint on save wasn't triggered with save menu shortcut (#40)
+* Not displaying results if cursor on EOF (#50)
 * Previous highlights weren't cleared
 
 ### Performance Improvements
-* Wait 1000ms between two lint on changes ([#32](https://github.com/AtomLinter/Linter/issues/32))
+* Wait 1000ms between two lint on changes (#32)
 
 ### New Linters
 * [linter-pylint](https://atom.io/packages/linter-pylint), for Python, using `pylint`


### PR DESCRIPTION
There's no real need to have the full URL inside the README. Should the name of the repo change for some reason (or the URL to issues), just writing #<number of issue/PR> will still work. These two issue links didn't work either way (it's `/issues` not `/issue`).

Since now the raw README format is inconsistent I wanted to ask you if I should change all links to the short syntax or just add the `s` to the links and continue to use your style.
