### PR TITLE
fix too intrusive highlight

### DIFF
--- a/stylesheets/highlights.less
+++ b/stylesheets/highlights.less
@@ -5,20 +5,21 @@
     background: linear-gradient(
       to bottom,
       @background-color-warning 0%,
-      fadeout(@background-color-warning, 70%) 20%,
-      fadeout(@background-color-warning, 70%) 80%,
+      fadeout(@background-color-warning, 93%) 5%,
+      fadeout(@background-color-warning, 93%) 95%,
       @background-color-warning 100%);
-    border-left: 2px solid @background-color-warning;
-    border-right: 2px solid @background-color-warning;
+    border-left: 1px solid @background-color-warning;
+    border-right: 1px solid @background-color-warning;
   }
   &.linter-error .region {
     background: linear-gradient(
       to bottom,
       @background-color-error 0%,
-      fadeout(@background-color-error, 70%) 20%,
-      fadeout(@background-color-error, 70%) 80%,
+      fadeout(@background-color-error, 93%) 5%,
+      fadeout(@background-color-error, 93%) 95%,
       @background-color-error 100%);
-    border-left: 2px solid @background-color-error;
-    border-right: 2px solid @background-color-error;
+    border-left: 1px solid @background-color-error;
+    border-right: 1px solid @background-color-error;
   }
 }
+


### PR DESCRIPTION
When writing highlights were too intrusive, I could not even see the text and even less select with the mouse.
I like to work with dark background, maybe in lighter background was working better.
You can see the preview here:
![image](https://cloud.githubusercontent.com/assets/1930175/5062977/66a220c2-6dd4-11e4-8eb2-0cb3cb6c6cc0.png)
![captura de pantalla 2014-11-16 a la s 21 01 34](https://cloud.githubusercontent.com/assets/1930175/5062981/9959dbe0-6dd4-11e4-9b5d-898b3d71e1cd.png)
