### PR TITLE
Fixed inline-comments.gif url to not me relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Lint your code with ease in [Atom](http://atom.io).
 
-![atom-inline-messages](inline-comments.gif)
+![atom-inline-messages](https://raw.githubusercontent.com/AtomLinter/Linter/master/inline-comments.gif)
 
 The idea is to stop the linter plugins war, by providing a top level API for linters to parse and display errors in the Atom editor.
 


### PR DESCRIPTION
Fixed the inline-comments.gif image so it references the image in the repo directly. This way the image will be show correctly on any website, not just the Github website.
