### PR TITLE
Remove panel classes

### DIFF
--- a/lib/statusbar-view.coffee
+++ b/lib/statusbar-view.coffee
@@ -7,7 +7,7 @@ _ = require 'lodash'
 class StatusBarView extends View
 
   @content: ->
-    @div class: 'tool-panel panel-bottom padded text-smaller', =>
+    @div class: 'padded text-smaller', =>
       @dl class: 'linter-statusbar', outlet: 'violations',
 
   initialize: ->


### PR DESCRIPTION
These classes get put on the containing `atom-panel` element with the new panel API, so they no longer need to be on the view.
