### PR TITLE
Add severity attribute

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -58,6 +58,7 @@ export function fillMessage(message: Linter$Message, linterName: ?string) {
   message.name = message.name || linterName || null
   message.key = messageKey(message)
   if (!message.severity) {
-    message.severity = 'error'
+    message.severity = message.type === 'Warning' || message.type === 'warning' ? 'warning' :
+                       message.type === 'Info' || message.type === 'info' ? 'info' : 'error'
   }
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -53,3 +53,11 @@ export function messageKey(message: Linter$Message): string {
     ) : ''
   )
 }
+
+export function fillMessage(message: Linter$Message, linterName: ?string) {
+  message.name = message.name || linterName || null
+  message.key = messageKey(message)
+  if (!message.severity) {
+    message.severity = 'error'
+  }
+}

--- a/lib/message-registry.js
+++ b/lib/message-registry.js
@@ -4,7 +4,7 @@
 
 import { CompositeDisposable, Emitter } from 'atom'
 import debounce from 'sb-debounce'
-import { messageKey } from './helpers'
+import { fillMessage } from './helpers'
 import type { Disposable, TextBuffer } from 'atom'
 import type { Linter$Difference, Linter$Linter, Linter$Message } from './types'
 
@@ -70,8 +70,7 @@ export default class MessageRegistry {
         result.added = result.added.concat(entry.messages)
         result.messages = result.messages.concat(entry.messages)
         for (const message of entry.messages) {
-          message.name = message.name || entry.linter.name || null
-          message.key = messageKey(message)
+          fillMessage(message, entry.linter.name)
         }
         entry.oldMessages = entry.messages
         continue
@@ -90,15 +89,11 @@ export default class MessageRegistry {
       entry.oldMessages = []
 
       for (const message of oldMessages) {
-        if (!message.key) {
-          message.key = messageKey(message)
-        }
         oldKeys.add(message.key)
       }
 
       for (const message of entry.messages) {
-        message.name = message.name || entry.linter.name || null
-        message.key = messageKey(message)
+        fillMessage(message)
         newKeys.add(message.key)
         if (!oldKeys.has(message.key)) {
           foundNew = true

--- a/lib/message-registry.js
+++ b/lib/message-registry.js
@@ -93,7 +93,7 @@ export default class MessageRegistry {
       }
 
       for (const message of entry.messages) {
-        fillMessage(message)
+        fillMessage(message, entry.linter.name)
         newKeys.add(message.key)
         if (!oldKeys.has(message.key)) {
           foundNew = true

--- a/lib/message-registry.js
+++ b/lib/message-registry.js
@@ -17,7 +17,6 @@ type Linter$Message$Map = {
   oldMessages: Array<Linter$Message>
 }
 
-
 export default class MessageRegistry {
   emitter: Emitter;
   messages: Array<Linter$Message>;

--- a/lib/types.js
+++ b/lib/types.js
@@ -6,14 +6,15 @@ export type Atom$Point = [number, number]
 export type Atom$Range = [Atom$Point, Atom$Point] |
   {start: {row: number, column: number}, end: {row: number, column: number}}
 export type Linter$Message = {
+  key: string,
   type: string,
   text?: string,
   html?: string,
   name?: ?string,
-  filePath?: string,
   range?: Atom$Range,
   trace?: Array<Linter$Message>,
-  key: string
+  severity: 'error' | 'warning' | 'info',
+  filePath?: string
 }
 export type Linter$State = {}
 export type Linter$Linter = {

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -4,6 +4,8 @@
 
 import type { Linter$UI, Linter$Linter, Linter$Message } from './types'
 
+const VALID_SEVERITY = new Set(['error', 'warning', 'info'])
+
 export function ui(provider: Linter$UI): boolean {
   let message
 
@@ -88,6 +90,8 @@ export function messages(entries: Array<Linter$Message>): boolean {
         message = 'Linter message.class must be a string'
       } else if (typeof entry.filePath !== 'undefined' && typeof entry.filePath !== 'string') {
         message = 'Linter message.filePath must be a string'
+      } else if (entry.severity && !VALID_SEVERITY.has(entry.severity)) {
+        message = 'Linter message.severity must be a valid one'
       } else if (entry.trace) {
         messages(entry.trace)
       }

--- a/spec/message-registry-spec.js
+++ b/spec/message-registry-spec.js
@@ -177,7 +177,7 @@ describe('Message Registry', function() {
       expect(called).toBe(4)
     })
 
-    it('sets key on messages', function() {
+    it('sets key, severity and name on messages', function() {
       const linter = {}
       const buffer = {}
       const messageFirst = getMessage()
@@ -196,6 +196,10 @@ describe('Message Registry', function() {
           expect(added).toEqual(messages)
           expect(typeof messages[0].key).toBe('string')
           expect(typeof messages[1].key).toBe('string')
+          expect(typeof messages[0].severity).toBe('string')
+          expect(typeof messages[1].severity).toBe('string')
+          expect(messages[0].name).toBe(null)
+          expect(messages[1].name).toBe(null)
         } else {
           // One removed, one added
           expect(added.length).toBe(1)
@@ -204,6 +208,10 @@ describe('Message Registry', function() {
           expect(messages.indexOf(added[0])).not.toBe(-1)
           expect(typeof messages[0].key).toBe('string')
           expect(typeof messages[1].key).toBe('string')
+          expect(typeof messages[0].severity).toBe('string')
+          expect(typeof messages[1].severity).toBe('string')
+          expect(messages[0].name).toBe(null)
+          expect(messages[1].name).toBe(null)
         }
       })
 

--- a/spec/validate-spec.coffee
+++ b/spec/validate-spec.coffee
@@ -111,3 +111,13 @@ describe 'validate', ->
       validate.messages([{type: 'Error', text: 'Well', class: 'error', filePath: '/'}], {name: ''})
       validate.messages([{type: 'Error', html: 'Well', class: 'error', filePath: '/'}], {name: ''})
       validate.messages([{type: 'Error', html: document.createElement('div'), class: 'error', filePath: '/'}], {name: ''})
+    it 'throws if severity is incorrect', ->
+      expect ->
+        validate.messages([{type: 'Error', text: 'Hey', severity: 'invalid'}])
+      .toThrow()
+      expect ->
+        validate.messages([{type: 'Error', text: 'Hey', severity: 123}])
+      .toThrow()
+      validate.messages([{type: 'Error', text: 'Hey', severity: 'error'}])
+      validate.messages([{type: 'Error', text: 'Hey', severity: 'warning'}])
+      validate.messages([{type: 'Error', text: 'Hey', severity: 'info'}])


### PR DESCRIPTION
It has limited set of values, these are case sensitive, `error`, `warning` and `info`

They are not shown to the user but used for other internal purposes, we might even use these to paint the messages so the providers don't have to provide style for each message type.

Another benefit of having this attribute is that we can show in the UI how many are warnings and how many are infos

- [x] Add validation for the new attribute
- [x] Make message registry set the default value to `error`
- [x] Update wiki to include the new attribute

Fixes #878