### PR TITLE
Add config to lint preview tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add severity attribute to linter messages, see the API doc for the new message struct
 * Respect core config `excludeVcsIgnoredPaths` to ignore linting on files
 * Defer linting on preview tabs (Fixes #1041)
+* Add `lintPreviewTabs` config
 
 ## 1.11.4
 

--- a/lib/linter-registry.js
+++ b/lib/linter-registry.js
@@ -14,6 +14,7 @@ export default class LinterRegistry {
   linters: Set<Linter$Regular>;
   ignoreGlob: string;
   ignoreVCS: boolean;
+  lintPreviewTabs: boolean;
   subscriptions: CompositeDisposable;
 
   constructor() {
@@ -24,6 +25,9 @@ export default class LinterRegistry {
 
     this.subscriptions.add(atom.config.observe('linter.ignoreGlob', ignoreGlob => {
       this.ignoreGlob = ignoreGlob
+    }))
+    this.subscriptions.add(atom.config.observe('linter.lintPreviewTabs', lintPreviewTabs => {
+      this.lintPreviewTabs = lintPreviewTabs
     }))
     this.subscriptions.add(atom.config.observe('core.excludeVcsIgnoredPaths', ignoreVCS => {
       this.ignoreVCS = ignoreVCS
@@ -59,7 +63,7 @@ export default class LinterRegistry {
       !filePath                                                                 || // Not saved anywhere yet
       editor !== atom.workspace.getActiveTextEditor()                           || // Not active
       isPathIgnored(editor.getPath(), this.ignoreGlob, this.ignoreVCS)          || // Ignored by VCS or Glob
-      editor.hasTerminatedPendingState === false
+      (!this.lintPreviewTabs && editor.hasTerminatedPendingState === false)
     ) {
       return false
     }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,10 @@
       "title": "Ignore files matching this Glob",
       "type": "string",
       "default": "{\\,/}**{\\,/}*.min.{js,css}"
+    },
+    "lintPreviewTabs": {
+      "type": "boolean",
+      "default": true
     }
   }
 }

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -54,3 +54,48 @@ describe 'Linter Config', ->
           linter.commands.lint()
           expect(linterProvider.lint).toHaveBeenCalled()
           expect(linterProvider.lint.calls.length).toBe(1)
+
+  describe 'lintPreviewTabs', ->
+    it 'does not lint preview tabs if disabled', ->
+      atom.config.set('linter.lintPreviewTabs', false)
+
+      linterProvider = {
+        grammarScopes: ['*']
+        lintOnFly: false
+        modifiesBuffer: false
+        scope: 'file'
+        lint: jasmine.createSpy('linter::lint')
+      }
+      linter.addLinter(linterProvider)
+      waitsForPromise ->
+        atom.workspace.open(__filename).then ->
+          editor = atom.workspace.getActiveTextEditor()
+
+          editor.hasTerminatedPendingState = false
+          linter.commands.lint()
+          expect(linterProvider.lint).not.toHaveBeenCalled()
+          editor.hasTerminatedPendingState = true
+          linter.commands.lint()
+          expect(linterProvider.lint).toHaveBeenCalled()
+
+    it 'lints if enabled', ->
+      atom.config.set('linter.lintPreviewTabs', true)
+
+      linterProvider = {
+        grammarScopes: ['*']
+        lintOnFly: false
+        modifiesBuffer: false
+        scope: 'file'
+        lint: jasmine.createSpy('linter::lint')
+      }
+      linter.addLinter(linterProvider)
+      waitsForPromise ->
+        atom.workspace.open(__filename).then ->
+          editor = atom.workspace.getActiveTextEditor()
+
+          editor.hasTerminatedPendingState = false
+          linter.commands.lint()
+          expect(linterProvider.lint).toHaveBeenCalled()
+          editor.hasTerminatedPendingState = true
+          linter.commands.lint()
+          expect(linterProvider.lint.calls.length).toBe(2)

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -23,7 +23,6 @@ describe 'Linter Config', ->
 
       waitsForPromise ->
         atom.workspace.open(filePath).then ->
-          atom.workspace.getActiveTextEditor().terminatePendingState()
           linter.commands.lint()
           expect(linterProvider.lint).not.toHaveBeenCalled()
           atom.config.set('linter.ignoreGlob', '{\,/}**{\,/}*.min.css')
@@ -46,7 +45,6 @@ describe 'Linter Config', ->
 
       waitsForPromise ->
         atom.workspace.open(ignoredFilePath).then ->
-          atom.workspace.getActiveTextEditor().terminatePendingState()
           linter.commands.lint()
           expect(linterProvider.lint).toHaveBeenCalled()
           expect(linterProvider.lint.calls.length).toBe(1)

--- a/spec/linter-registry-spec.coffee
+++ b/spec/linter-registry-spec.coffee
@@ -10,7 +10,6 @@ describe 'linter-registry', ->
     waitsForPromise ->
       atom.workspace.open('file.txt').then ->
         editor = atom.workspace.getActiveTextEditor()
-        editor.terminatePendingState()
     waitsForPromise ->
       atom.packages.activatePackage('linter')
     linterRegistry?.dispose()
@@ -81,7 +80,6 @@ describe 'linter-registry', ->
       linterRegistry.addLinter(linter)
       waitsForPromise ->
         atom.workspace.open('test2.txt').then ->
-          atom.workspace.getActiveTextEditor().terminatePendingState()
           linterRegistry.lint({onChange: false, editor}).then (result) ->
             expect(result).toBe(false)
     it "doesn't lint if textEditor doesn't have a path", ->
@@ -96,7 +94,6 @@ describe 'linter-registry', ->
       linterRegistry.addLinter(linter)
       waitsForPromise ->
         atom.workspace.open('someNonExistingFile.txt').then ->
-          atom.workspace.getActiveTextEditor().terminatePendingState()
           linterRegistry.lint({onChange: false, editor}).then (result) ->
             expect(result).toBe(false)
     it 'only uses results from the latest invocation', ->

--- a/spec/linter-registry-spec.coffee
+++ b/spec/linter-registry-spec.coffee
@@ -51,23 +51,6 @@ describe 'linter-registry', ->
       expect(linter.deactivated).toBe(true)
 
   describe '::lint', ->
-    it "doesn't lint if textEditor is in pending state", ->
-      editorLinter = new EditorLinter(editor)
-      linter = {
-        grammarScopes: ['*']
-        lintOnFly: false
-        modifiesBuffer: false
-        scope: 'file'
-        lint: jasmine.createSpy('lint')
-      }
-      editor.hasTerminatedPendingState = false
-      linterRegistry.addLinter(linter)
-      linterRegistry.lint({onChange: false, editor})
-      expect(linter.lint).not.toHaveBeenCalled()
-      editor.hasTerminatedPendingState = true
-      linterRegistry.lint({onChange: false, editor})
-      expect(linter.lint).toHaveBeenCalled()
-
     it "doesn't lint if textEditor isn't active one", ->
       editorLinter = new EditorLinter(editor)
       linter = {


### PR DESCRIPTION
Setting this enabled by default because that's the current behavior.

- [x] Add the new config
- [x] Respect the new config when triggering providers
- [x] Document change in changelog
- [x] Write specs for change