### PR TITLE
Adding coffee-script devDep to package.json, along with readme: field, hence fixing #1163

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "linter",
   "main": "./lib/index",
   "author": "steelbrain",
+  "readme": "./README.md",
   "version": "1.11.4",
   "description": "A Base Linter with Cow Powers",
   "repository": "https://github.com/steelbrain/linter",
@@ -47,7 +48,8 @@
     "eslint": "^2.4.0",
     "eslint-config-airbnb": "^6.0.2",
     "eslint-plugin-react": "^4.2.1",
-    "jasmine-fix": "^1.0.0"
+    "jasmine-fix": "^1.0.0",
+    "coffee-script": "^1.7.0"
   },
   "package-deps": [
     "linter-ui-default"


### PR DESCRIPTION
Hi,

Per title this pull request should resolve #1163 and it would be nice if you could publish this edit once you accept this pull request by running:

```bash
apm publish patch
```

This way I can more easily use this fix when I build Atom on Arch Linux with this package pre-installed. 

Thanks for your time,
Brenton