### PR TITLE
Search all panes for file to open; consolidate duplicated code

### DIFF
--- a/lib/commands.coffee
+++ b/lib/commands.coffee
@@ -68,27 +68,26 @@ class Commands
     # That way the index can be ++ an -- without caring about the array bounds.
     messages[index %% messages.length]
 
+  gotoError: (index) ->
+    message = @getMessage(@index)
+    return unless message?.filePath
+    return unless message?.range
+    atom.workspace.open(message.filePath, {searchAllPanes: true}).then ->
+      atom.workspace.getActiveTextEditor().setCursorBufferPosition(message.range.start)
+
   nextError: ->
     if @index?
       @index++
     else
       @index = 0
-    message = @getMessage(@index)
-    return unless message?.filePath
-    return unless message?.range
-    atom.workspace.open(message.filePath).then ->
-      atom.workspace.getActiveTextEditor().setCursorBufferPosition(message.range.start)
+    @gotoError(@index)
 
   previousError: ->
     if @index?
       @index--
     else
       @index = 0
-    message = @getMessage(@index)
-    return unless message?.filePath
-    return unless message?.range
-    atom.workspace.open(message.filePath).then ->
-      atom.workspace.getActiveTextEditor().setCursorBufferPosition(message.range.start)
+    @gotoError(@index)
 
   dispose: ->
     @messages = null


### PR DESCRIPTION
Files are currently opened in the active pane, even if they are already open in another pane. To my mind it's better to reuse an open file even in another pane, since most people won't want to have the file open more than once. 

An extension could be to add an option to allow the "current pane" or "all panes" behaviour to be chosen on a per-user basis. I can add that if you'd like but I suspect it's not really needed.

The commit also reduces some obvious code duplication by introducing a gotoError method.