### PR TITLE
Refresh the tooltip when its current message gets removed

### DIFF
--- a/lib/linter-views.js
+++ b/lib/linter-views.js
@@ -16,7 +16,6 @@ export default class LinterViews {
     this.editors = editorRegistry
     this.bottomBar = null // To be added when status-bar service is consumed
     this.bubble = null
-    this.bubbleRange = null
 
     this.subscriptions.add(this.bottomPanel)
     this.subscriptions.add(this.bottomContainer)
@@ -74,30 +73,30 @@ export default class LinterViews {
       return
     }
     const point = editorLinter.editor.getCursorBufferPosition()
-    if (this.bubbleRange && this.bubbleRange.containsPoint(point)) {
+    if (this.bubble && editorLinter.messages.has(this.bubble.message) && this.bubble.range.containsPoint(point)) {
       return // The marker remains the same
     }
     this.removeBubble()
     for (let message of editorLinter.messages) {
       if (message.range && message.range.containsPoint(point)) {
-        this.bubbleRange = Range.fromObject([point, point])
-        this.bubble = editorLinter.editor.markBufferRange(this.bubbleRange, {invalidate: 'inside'})
-        this.bubble.onDidDestroy(() => {
+        const range = Range.fromObject([point, point])
+        const marker = editorLinter.editor.markBufferRange(range, {invalidate: 'inside'})
+        this.bubble = {message, range, marker}
+        marker.onDidDestroy(() => {
           this.bubble = null
-          this.bubbleRange = null
         })
-        editorLinter.editor.decorateMarker(this.bubble, {
+        editorLinter.editor.decorateMarker(marker, {
           type: 'overlay',
           item: createBubble(message)
         })
-        return
+        break
       }
     }
-    this.bubbleRange = null
   }
   removeBubble() {
     if (this.bubble) {
-      this.bubble.destroy()
+      this.bubble.marker.destroy()
+      this.bubble = null
     }
   }
   notifyEditorLinters({added, removed}) {
@@ -151,9 +150,6 @@ export default class LinterViews {
     if (this.bottomBar) {
       this.bottomBar.destroy()
     }
-    if (this.bubble) {
-      this.bubble.destroy()
-      this.bubbleRange = null
-    }
+    this.removeBubble()
   }
 }


### PR DESCRIPTION
`src/linter-view.js`'s `renderBubble` skips refreshing the tooltip when the cursor is within the currently shown tooltip's range. However the tooltip should get fully refreshed without skipping anything when its current message has been removed.

Here is an example of a situation when a stale tooltip is shown (using the current master 9338d172) even when the error it's showing gets fixed:

![before](https://cloud.githubusercontent.com/assets/19776768/16135830/dc8a795c-342e-11e6-9cad-02522392a45f.gif)

After the changes in this pull request the same situation looks like this:

![after](https://cloud.githubusercontent.com/assets/19776768/16135833/e0ca9c90-342e-11e6-86cb-9f9d2e63f1b4.gif)

The pull request tries to simplify internal state handling a bit (YMMV) by keeping all info related to the current tooltip in a single property called `bubble`. The property should be `null` when the tooltip is not shown. When the tooltip is shown then `bubble` should be an object containing all the relevant info (currently shown message, range & marker).