### PR TITLE
Consume API providers by fixed versions only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,7 @@
 env:
   global:
     - ATOM_LINT_WITH_BUNDLED_NODE="false"
-
-  matrix:
     - ATOM_CHANNEL=stable
-    - ATOM_CHANNEL=beta
 
 os:
   - linux

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "linter": {
       "versions": {
         "^1.0.0": "consumeLinterLegacy",
-        "^2.0.0": "consumeLinter"
+        "2.0.0": "consumeLinter"
       }
     },
     "linter-ui": {
       "versions": {
-        "^1.0.0": "consumeUI"
+        "1.0.0": "consumeUI"
       }
     }
   },


### PR DESCRIPTION
We still consume legacy linters (1.x) with semver so it shouldn't be a breaking change