### PR TITLE
Simplify export signature of IndieRegistry

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 
 import { Disposable } from 'atom'
 import Linter from './main'
-import type { State, UI, Linter as LinterProvider } from './types'
+import type { State, UI, Linter as LinterProvider, Indie } from './types'
 
 export default {
   state: null,
@@ -52,9 +52,8 @@ export default {
     })
   },
   provideIndie(): Object {
-    return {
-      register: (options: Object) => this.instance.registryIndie.register(options),
-    }
+    return (indie: Indie) =>
+      this.instance.registryIndie.register(indie)
   },
   deactivate() {
     this.instance.dispose()


### PR DESCRIPTION
It's Indie Registry v2 and nobody is using it because it's unreleased so this change doesn't break anything