### PR TITLE
Add installRecommendedPackages config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ export default {
   instance: null,
 
   activate(state: State) {
-    if (!atom.inSpecMode()) {
+    if (!atom.inSpecMode() && atom.config.get('linter.installRecommendedPackages')) {
       require('atom-package-deps').install('linter') // eslint-disable-line
     }
     this.instance = new Linter(state)

--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
     "linter-ui-default"
   ],
   "configSchema": {
+    "installRecommendedPackages": {
+      "description": "Installs recommended packages on startup",
+      "type": "boolean",
+      "default": true
+    },
     "lintOnFly": {
       "title": "Lint As You Type",
       "description": "Lint files while typing, without the need to save",


### PR DESCRIPTION
Pretty straight forward. Allows people to disable auto-install of linter-ui-default on boot.