### PR TITLE
Fix an inconsistent behavior bug with on change providers

### DIFF
--- a/lib/editor-linter.js
+++ b/lib/editor-linter.js
@@ -25,9 +25,10 @@ export default class EditorLinter {
     this.subscriptions.add(this.editor.onDidSave(debounce(() =>
       this.emitter.emit('should-lint', false)
     ), 16, true))
-    // FIXME: We have a bug where this is triggered on editor boot and triggers all fly linters
+    // NOTE: TextEditor::getBuffer immediately invokes the callback if the text editor was *just* created
+    // Using TextBuffer::getBuffer doesn't have the same behavior so using it instead.
     this.subscriptions.add(deferredSubscriptiveObserve(atom.config, 'linter.lintOnChangeInterval', interval =>
-      this.editor.onDidChange(debounce(() => {
+      this.editor.getBuffer().onDidChange(debounce(() => {
         this.emitter.emit('should-lint', true)
       }, interval))
     ))


### PR DESCRIPTION
They would be triggered on editor open without even changing anything. This fixes that behavior

I tried to add a spec, but wasn't able to repro the bug in spec window. I suppose it happens in the first place because of some internal atom bug or something. In any case, I've added a note above the fix to make sure it's not deleted in some refactoring