### PR TITLE
Use reference links

### DIFF
--- a/docs/examples/indie-linter-v2.md
+++ b/docs/examples/indie-linter-v2.md
@@ -1,6 +1,6 @@
 # Indie Linter v2
 
-The [Indie Linter API v2](../types/indie-linter-v2.md) demoed below supports [Messages v2](../types/linter-message-v2.md) only.
+The [Indie Linter API v2][] demoed below supports [Messages v2][] only.
 
 ## package.json
 
@@ -99,3 +99,6 @@ export function consumeIndie(registerIndie) {
   linter.clearMessages()
 }
 ```
+
+[Indie Linter API v2]: ../types/indie-linter-v2.md
+[Messages v2]: ../types/linter-message-v2.md

--- a/docs/examples/standard-linter-v2.md
+++ b/docs/examples/standard-linter-v2.md
@@ -1,7 +1,6 @@
 # Standard Linter v2
 
-The [Standard Linter API v2](../types/standard-linter-v2.md) demoed below
-supports [Messages v2](../types/linter-message-v2.md) only.
+The [Standard Linter API v2][] demoed below supports [Messages v2][] only.
 
 ## package.json
 
@@ -78,3 +77,6 @@ export function provideLinter() {
   }
 }
 ```
+
+[Standard Linter API v2]: ../types/standard-linter-v2.md
+[Messages v2]: ../types/linter-message-v2.md

--- a/docs/examples/ui-provider-v1.md
+++ b/docs/examples/ui-provider-v1.md
@@ -1,6 +1,6 @@
 # UI Provider v1
 
-This example demonstrates usage of [UI Provider v1 API](../types/ui-provider-v1.md)
+This example demonstrates usage of [UI Provider v1 API][]
 
 **Note**: Linter fills the messages with `version` and `key` keys to make
 telling the difference between `Message`s easy for UI providers.
@@ -78,3 +78,5 @@ export function provideUI() {
   }
 }
 ```
+
+[UI Provider v1 API]: ../types/ui-provider-v1.md

--- a/docs/guides/upgrading-to-indie-linter-v2.md
+++ b/docs/guides/upgrading-to-indie-linter-v2.md
@@ -47,7 +47,8 @@ upgrade from the old `IndieDelegate::setMessages` to
 `IndieDelegate::setAllMessages` because these two methods are functionally
 identical.
 
-The Message format used also needs to be updated to match the new [Messages v2](../types/linter-message-v2.md) format.
+The Message format used also needs to be updated to match the new
+[Message API v2][] format.
 
 ### Before
 
@@ -84,3 +85,5 @@ export function consumeIndie(registerIndie) {
   }])
 }
 ```
+
+[Message API v2]: ../types/linter-message-v2.md

--- a/docs/types/indie-linter-v2.md
+++ b/docs/types/indie-linter-v2.md
@@ -1,7 +1,7 @@
 # Indie Linter v2
 
 This document describes the type of Indie Linter v2, for an example in how to
-implement this in your own package see the see the [Example Usage](../examples/indie-linter-v2.md) document.
+implement this in your own package see the see the [Example Usage][] document.
 
 ## Types
 
@@ -45,3 +45,5 @@ class IndieDelegate {
 *   `setAllMessages` replaces the list of messages Linter has stored for your
     provider. Any existing messages, regardless of the file they are associated
     with, are discarded.
+
+[Example Usage]: ../examples/indie-linter-v2.md

--- a/docs/types/linter-message-v2.md
+++ b/docs/types/linter-message-v2.md
@@ -1,6 +1,7 @@
 # Linter Message v2
 
-This document describes the type of Linter Message v2. It's supported in [`Indie Linter v2`](indie-linter-v2.md) and [`Standard Linter v2`](standard-linter-v2.md).
+This document describes the type of Linter Message v2. It's supported in
+[`Indie Linter v2`][] and [`Standard Linter v2`][].
 
 ## Type
 
@@ -41,7 +42,7 @@ type Message = {
 
 **Q**: Which properties are optional?
 
-**A**: The type above uses [`flowtype`](https://flowtype.org/), `?` with the key
+**A**: The type above uses [`flowtype`][], `?` with the key
 indicates that it's optional and can be falsy.
 
 **Q**: What type of value to add in `description`?
@@ -59,9 +60,16 @@ the other solution type that was specifically built for text replacement.
 **Q**: What's the purpose of the `title` in a solution?
 
 **A**: Depends on the UI provider, the default Linter UI uses this attribute as
-it's title for [Intentions](https://atom.io/packages/intentions) package,
+it's title for [Intentions][] package,
 `Fix linter error` is the default one used at the time of writing this document.
 
 **Q**: What is `Point` and `Range`?
 
-**A**: These are references to built in [`Point`](https://atom.io/docs/api/latest/Point) and [`Range`](https://atom.io/docs/api/latest/Range) classes.
+**A**: These are references to built in [`Point`][] and [`Range`][] classes.
+
+[`Indie Linter v2`]: indie-linter-v2.md
+[`Standard Linter v2`]: standard-linter-v2.md
+[`flowtype`]: https://flowtype.org/
+[Intentions]: https://atom.io/packages/intentions
+[`Point`]: https://atom.io/docs/api/latest/Point
+[`Range`]: https://atom.io/docs/api/latest/Range

--- a/docs/types/standard-linter-v2.md
+++ b/docs/types/standard-linter-v2.md
@@ -1,7 +1,7 @@
 # Standard Linter v2
 
 This document describes the type of Standard Linter v2, for an example in how to
-implement this in your own package see the see the [Example Usage](../examples/standard-linter-v2.md) document.
+implement this in your own package see the see the [Example Usage][] document.
 
 ## Type
 
@@ -71,3 +71,5 @@ regardless of the scope of the current file.
 **Q**: How do I make linter use last messages for my provider?
 
 **A**: Return `null` from your provider to make it re-use last messages.
+
+[Example Usage]: ../examples/standard-linter-v2.md

--- a/docs/types/ui-provider-v1.md
+++ b/docs/types/ui-provider-v1.md
@@ -1,7 +1,7 @@
 # UI Provider v1
 
 This document describes the type of UI Provider v1, for an example in how to
-implement this in your own package see the see the [Example Usage](../examples/ui-provider-v1.md) document.
+implement this in your own package see the see the [Example Usage][] document.
 
 ## Type
 
@@ -38,3 +38,5 @@ UI object is the best place to run the activation logic.
 **A**: It is triggered when either your package or the linter package is
 deactivated. It's useful for destroying any Panels you might have registered for
 the UI.
+
+[Example Usage]: ../examples/ui-provider-v1.md


### PR DESCRIPTION
Clean up the look of the Markdown itself by using reference links where possible.