### PR TITLE
Reduce activation time

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": "steelbrain",
   "rules": {
+    "global-require": "off",
     "no-param-reassign": "off",
     "no-underscore-dangle": "off",
     "no-duplicate-imports": "off",

--- a/lib/editor-registry.js
+++ b/lib/editor-registry.js
@@ -4,7 +4,7 @@ import { Emitter, CompositeDisposable } from 'atom'
 import type { Disposable, TextEditor } from 'atom'
 import EditorLinter from './editor-linter'
 
-export default class EditorRegistry {
+class EditorRegistry {
   emitter: Emitter;
   lintOnOpen: boolean;
   subscriptions: CompositeDisposable;
@@ -55,3 +55,5 @@ export default class EditorRegistry {
     this.subscriptions.dispose()
   }
 }
+
+module.exports = EditorRegistry

--- a/lib/greeter/index.js
+++ b/lib/greeter/index.js
@@ -5,7 +5,7 @@ import greetV2Welcome from './greet-v2-welcome'
 
 // Note: This package should not be used from "Main" class,
 // Instead it should be used from the main package entry point directly
-export default class Greeter {
+class Greeter {
   notifications: Set<Object>;
   constructor() {
     this.notifications = new Set()
@@ -20,3 +20,5 @@ export default class Greeter {
     this.notifications.clear()
   }
 }
+
+module.exports = Greeter

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,11 +20,9 @@ export default {
     // TODO: Remove this after a few version bumps
     const oldConfigCallbackID = window.requestIdleCallback(async function linterOldConfigs() {
       idleCallbacks.delete(oldConfigCallbackID)
-      /* eslint-disable global-require */
-      const Greeter = require('./greeter')
       const FS = require('sb-fs')
       const Path = require('path')
-      /* eslint-enable global-require */
+      const Greeter = require('./greeter')
 
       // Greet the user if they are coming from Linter v1
       const greeter = new Greeter()

--- a/lib/index.js
+++ b/lib/index.js
@@ -121,11 +121,11 @@ export default {
   },
   provideIndie(): Object {
     return indie =>
-      instance.registryIndie.register(indie, 2)
+      instance.addIndie(indie)
   },
   provideIndieLegacy(): Object {
     return {
-      register: indie => instance.registryIndie.register(indie, 1),
+      register: indie => instance.addLegacyIndie(indie),
     }
   },
   deactivate() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,56 +1,65 @@
 /* @flow */
 
-import FS from 'sb-fs'
-import Path from 'path'
-import { Disposable } from 'atom'
+import { CompositeDisposable, Disposable } from 'atom'
 
 import Linter from './main'
-import Greeter from './greeter'
 import type { UI, Linter as LinterProvider } from './types'
 
-let greeter
+// Internal variables
 let instance
 
+const idleCallbacks = new Set()
+
 export default {
-  async activate() {
-    greeter = new Greeter()
+  activate() {
+    this.subscriptions = new CompositeDisposable()
+
     instance = new Linter()
+    this.subscriptions.add(instance)
 
-    const linterConfigs = atom.config.get('linter')
-    // Unset v1 configs
-    const removedV1Configs = [
-      'lintOnFly',
-      'lintOnFlyInterval',
-      'ignoredMessageTypes',
-      'ignoreVCSIgnoredFiles',
-      'ignoreMatchedFiles',
-      'showErrorInline',
-      'inlineTooltipInterval',
-      'gutterEnabled',
-      'gutterPosition',
-      'underlineIssues',
-      'showProviderName',
-      'showErrorPanel',
-      'errorPanelHeight',
-      'alwaysTakeMinimumSpace',
-      'displayLinterInfo',
-      'displayLinterStatus',
-      'showErrorTabLine',
-      'showErrorTabFile',
-      'showErrorTabProject',
-      'statusIconScope',
-      'statusIconPosition',
-    ]
-    if (removedV1Configs.some(config => ({}.hasOwnProperty.call(linterConfigs, config)))) {
-      greeter.showWelcome()
-    }
-    removedV1Configs.forEach((e) => { atom.config.unset(`linter.${e}`) })
+    // TODO: Remove this after a few version bumps
+    const oldConfigCallbackID = window.requestIdleCallback(async function linterOldConfigs() {
+      idleCallbacks.delete(oldConfigCallbackID)
+      /* eslint-disable global-require */
+      const Greeter = require('./greeter')
+      const FS = require('sb-fs')
+      const Path = require('path')
+      /* eslint-enable global-require */
 
-    if (!atom.inSpecMode()) {
-      // eslint-disable-next-line global-require
-      require('atom-package-deps').install('linter', true)
+      // Greet the user if they are coming from Linter v1
+      const greeter = new Greeter()
+      this.subscriptions.add(greeter)
+      const linterConfigs = atom.config.get('linter')
+      // Unset v1 configs
+      const removedV1Configs = [
+        'lintOnFly',
+        'lintOnFlyInterval',
+        'ignoredMessageTypes',
+        'ignoreVCSIgnoredFiles',
+        'ignoreMatchedFiles',
+        'showErrorInline',
+        'inlineTooltipInterval',
+        'gutterEnabled',
+        'gutterPosition',
+        'underlineIssues',
+        'showProviderName',
+        'showErrorPanel',
+        'errorPanelHeight',
+        'alwaysTakeMinimumSpace',
+        'displayLinterInfo',
+        'displayLinterStatus',
+        'showErrorTabLine',
+        'showErrorTabFile',
+        'showErrorTabProject',
+        'statusIconScope',
+        'statusIconPosition',
+      ]
+      if (removedV1Configs.some(config => ({}.hasOwnProperty.call(linterConfigs, config)))) {
+        greeter.showWelcome()
+      }
+      removedV1Configs.forEach((e) => { atom.config.unset(`linter.${e}`) })
 
-      // TODO: Remove this after a few version bumps
+      // There was an external config file in use briefly, migrate any use of that to settings
       const oldConfigFile = Path.join(atom.getConfigDirPath(), 'linter-config.json')
       if (await FS.exists(oldConfigFile)) {
         let disabledProviders = atom.config.get('linter.disabledProviders')
@@ -63,7 +72,17 @@ export default {
           await FS.unlink(oldConfigFile)
         } catch (_) { /* No Op */ }
       }
-    }
+    }.bind(this))
+    idleCallbacks.add(oldConfigCallbackID)
+
+    const linterDepsCallback = window.requestIdleCallback(function linterDepsInstall() {
+      idleCallbacks.delete(linterDepsCallback)
+      if (!atom.inSpecMode()) {
+        // eslint-disable-next-line global-require
+        require('atom-package-deps').install('linter', true)
+      }
+    })
+    idleCallbacks.add(linterDepsCallback)
   },
   consumeLinter(linter: LinterProvider): Disposable {
     const linters = [].concat(linter)
@@ -110,7 +129,8 @@ export default {
     }
   },
   deactivate() {
-    instance.dispose()
-    greeter.dispose()
+    idleCallbacks.forEach(callbackID => window.cancelIdleCallback(callbackID))
+    idleCallbacks.clear()
+    this.subscriptions.dispose()
   },
 }

--- a/lib/indie-registry.js
+++ b/lib/indie-registry.js
@@ -7,7 +7,7 @@ import IndieDelegate from './indie-delegate'
 import { indie as validateIndie } from './validate'
 import type { Indie } from './types'
 
-export default class IndieRegistry {
+class IndieRegistry {
   emitter: Emitter;
   delegates: Set<IndieDelegate>;
   subscriptions: CompositeDisposable;
@@ -49,3 +49,5 @@ export default class IndieRegistry {
     this.subscriptions.dispose()
   }
 }
+
+module.exports = IndieRegistry

--- a/lib/linter-registry.js
+++ b/lib/linter-registry.js
@@ -9,7 +9,7 @@ import * as Validate from './validate'
 import { $version, $activated, $requestLatest, $requestLastReceived } from './helpers'
 import type { Linter } from './types'
 
-export default class LinterRegistry {
+class LinterRegistry {
   emitter: Emitter;
   linters: Set<Linter>;
   lintOnChange: boolean;
@@ -155,3 +155,5 @@ export default class LinterRegistry {
     this.subscriptions.dispose()
   }
 }
+
+module.exports = LinterRegistry

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,18 +1,19 @@
 /* @flow */
 
-import arrayUnique from 'lodash.uniq'
 import { CompositeDisposable } from 'atom'
 
-import manifest from '../package.json'
 import Commands from './commands'
-import UIRegistry from './ui-registry'
-import ToggleView from './toggle-view'
-import IndieRegistry from './indie-registry'
-import LinterRegistry from './linter-registry'
-import MessageRegistry from './message-registry'
-import EditorsRegistry from './editor-registry'
-import * as Helpers from './helpers'
 import type { UI, Linter as LinterProvider } from './types'
+
+let Helpers
+let manifest
+let ToggleView
+let UIRegistry
+let arrayUnique
+let IndieRegistry
+let LinterRegistry
+let EditorsRegistry
+let MessageRegistry
 
 class Linter {
   commands: Commands;
@@ -22,25 +23,17 @@ class Linter {
   registryLinters: LinterRegistry;
   registryMessages: MessageRegistry;
   subscriptions: CompositeDisposable;
+  idleCallbacks: Set<number>;
 
   constructor() {
-    this.commands = new Commands()
-    this.registryUI = new UIRegistry()
-    this.registryIndie = new IndieRegistry()
-    this.registryEditors = new EditorsRegistry()
-    this.registryLinters = new LinterRegistry()
-    this.registryMessages = new MessageRegistry()
-
+    this.idleCallbacks = new Set()
     this.subscriptions = new CompositeDisposable()
 
+    this.commands = new Commands()
     this.subscriptions.add(this.commands)
-    this.subscriptions.add(this.registryUI)
-    this.subscriptions.add(this.registryIndie)
-    this.subscriptions.add(this.registryMessages)
-    this.subscriptions.add(this.registryEditors)
-    this.subscriptions.add(this.registryLinters)
 
     this.commands.onShouldLint(() => {
+      this.registryEditorsInit()
       const editorLinter = this.registryEditors.get(atom.workspace.getActiveTextEditor())
       if (editorLinter) {
         editorLinter.lint()
@@ -48,6 +41,7 @@ class Linter {
     })
     this.commands.onShouldToggleActiveEditor(() => {
       const textEditor = atom.workspace.getActiveTextEditor()
+      this.registryEditorsInit()
       const editor = this.registryEditors.get(textEditor)
       if (editor) {
         editor.dispose()
@@ -55,9 +49,14 @@ class Linter {
         this.registryEditors.createFromTextEditor(textEditor)
       }
     })
-    // NOTE: ESLint arrow-parens rule has a bug
-    // eslint-disable-next-line arrow-parens
     this.commands.onShouldDebug(async () => {
+      if (!Helpers) {
+        Helpers = require('./helpers')
+      }
+      if (!manifest) {
+        manifest = require('../package.json')
+      }
+      this.registryLintersInit()
       const linters = this.registryLinters.getLinters()
       const textEditor = atom.workspace.getActiveTextEditor()
       const textEditorScopes = Helpers.getEditorCursorScopes(textEditor)
@@ -88,81 +87,176 @@ class Linter {
       })
     })
     this.commands.onShouldToggleLinter((action) => {
-      const toggleView = new ToggleView(action, arrayUnique(this.registryLinters.getLinters().map(linter => linter.name)))
+      if (!ToggleView) {
+        ToggleView = require('./toggle-view')
+      }
+      if (!arrayUnique) {
+        arrayUnique = require('lodash.uniq')
+      }
+      this.registryLintersInit()
+      const toggleView = new ToggleView(action,
+        arrayUnique(this.registryLinters.getLinters().map(linter => linter.name)))
       toggleView.onDidDispose(() => {
         this.subscriptions.remove(toggleView)
       })
       toggleView.onDidDisable((name) => {
         const linter = this.registryLinters.getLinters().find(entry => entry.name === name)
         if (linter) {
+          this.registryMessagesInit()
           this.registryMessages.deleteByLinter(linter)
         }
       })
       toggleView.show()
       this.subscriptions.add(toggleView)
     })
-    this.registryIndie.observe((indieLinter) => {
-      indieLinter.onDidDestroy(() => {
-        this.registryMessages.deleteByLinter(indieLinter)
-      })
-    })
-    this.registryEditors.observe((editorLinter) => {
-      editorLinter.onShouldLint((onChange) => {
-        this.registryLinters.lint({ onChange, editor: editorLinter.getEditor() })
-      })
-      editorLinter.onDidDestroy(() => {
-        this.registryMessages.deleteByBuffer(editorLinter.getEditor().getBuffer())
-      })
-    })
-    this.registryIndie.onDidUpdate(({ linter, messages }) => {
-      this.registryMessages.set({ linter, messages, buffer: null })
-    })
-    this.registryLinters.onDidUpdateMessages(({ linter, messages, buffer }) => {
-      this.registryMessages.set({ linter, messages, buffer })
-    })
-    this.registryLinters.onDidBeginLinting(({ linter, filePath }) => {
-      this.registryUI.didBeginLinting(linter, filePath)
-    })
-    this.registryLinters.onDidFinishLinting(({ linter, filePath }) => {
-      this.registryUI.didFinishLinting(linter, filePath)
-    })
-    this.registryMessages.onDidUpdateMessages((difference) => {
-      this.registryUI.render(difference)
-    })
 
-    this.registryEditors.activate()
-
-    setTimeout(() => {
-      // NOTE: Atom triggers this on boot so wait a while
-      if (!this.subscriptions.disposed) {
+    const projectPathChangeCallbackID = window.requestIdleCallback(
+      function projectPathChange() {
+        this.idleCallbacks.delete(projectPathChangeCallbackID)
+        // NOTE: Atom triggers this on boot so wait a while
         this.subscriptions.add(atom.project.onDidChangePaths(() => {
           this.commands.lint()
         }))
-      }
-    }, 100)
+      }.bind(this))
+    this.idleCallbacks.add(projectPathChangeCallbackID)
+
+    const registryEditorsInitCallbackID = window.requestIdleCallback(
+      function registryEditorsIdleInit() {
+        this.idleCallbacks.delete(registryEditorsInitCallbackID)
+        // This will be called on the fly if needed, but needs to run on it's
+        // own at some point or linting on open or on change will never trigger
+        this.registryEditorsInit()
+      }.bind(this))
+    this.idleCallbacks.add(registryEditorsInitCallbackID)
   }
   dispose() {
+    this.idleCallbacks.forEach(callbackID => window.cancelIdleCallback(callbackID))
+    this.idleCallbacks.clear()
     this.subscriptions.dispose()
   }
 
-  // API methods for providing/consuming services
-  addUI(ui: UI) {
-    this.registryUI.add(ui)
+  registryEditorsInit() {
+    if (this.registryEditors) {
+      return
+    }
+    if (!EditorsRegistry) {
+      EditorsRegistry = require('./editor-registry')
+    }
+    this.registryEditors = new EditorsRegistry()
+    this.subscriptions.add(this.registryEditors)
+    this.registryEditors.observe((editorLinter) => {
+      editorLinter.onShouldLint((onChange) => {
+        this.registryLintersInit()
+        this.registryLinters.lint({ onChange, editor: editorLinter.getEditor() })
+      })
+      editorLinter.onDidDestroy(() => {
+        this.registryMessagesInit()
+        this.registryMessages.deleteByBuffer(editorLinter.getEditor().getBuffer())
+      })
+    })
+    this.registryEditors.activate()
+  }
+  registryLintersInit() {
+    if (this.registryLinters) {
+      return
+    }
+    if (!LinterRegistry) {
+      LinterRegistry = require('./linter-registry')
+    }
+    this.registryLinters = new LinterRegistry()
+    this.subscriptions.add(this.registryLinters)
+    this.registryLinters.onDidUpdateMessages(({ linter, messages, buffer }) => {
+      this.registryMessagesInit()
+      this.registryMessages.set({ linter, messages, buffer })
+    })
+    this.registryLinters.onDidBeginLinting(({ linter, filePath }) => {
+      this.registryUIInit()
+      this.registryUI.didBeginLinting(linter, filePath)
+    })
+    this.registryLinters.onDidFinishLinting(({ linter, filePath }) => {
+      this.registryUIInit()
+      this.registryUI.didFinishLinting(linter, filePath)
+    })
+  }
+  registryIndieInit() {
+    if (this.registryIndie) {
+      return
+    }
+    if (!IndieRegistry) {
+      IndieRegistry = require('./indie-registry')
+    }
+    this.registryIndie = new IndieRegistry()
+    this.subscriptions.add(this.registryIndie)
+    this.registryIndie.observe((indieLinter) => {
+      indieLinter.onDidDestroy(() => {
+        this.registryMessagesInit()
+        this.registryMessages.deleteByLinter(indieLinter)
+      })
+    })
+    this.registryIndie.onDidUpdate(({ linter, messages }) => {
+      this.registryMessagesInit()
+      this.registryMessages.set({ linter, messages, buffer: null })
+    })
+  }
+  registryMessagesInit() {
+    if (this.registryMessages) {
+      return
+    }
+    if (!MessageRegistry) {
+      MessageRegistry = require('./message-registry')
+    }
+    this.registryMessages = new MessageRegistry()
+    this.subscriptions.add(this.registryMessages)
+    this.registryMessages.onDidUpdateMessages((difference) => {
+      this.registryUIInit()
+      this.registryUI.render(difference)
+    })
+  }
+  registryUIInit() {
+    if (this.registryUI) {
+      return
+    }
+    if (!UIRegistry) {
+      UIRegistry = require('./ui-registry')
+    }
+    this.registryUI = new UIRegistry()
+    this.subscriptions.add(this.registryUI)
+  }
 
+  // API methods for providing/consuming services
+  // UI
+  addUI(ui: UI) {
+    this.registryUIInit()
+    this.registryUI.add(ui)
+    this.registryMessagesInit()
     const messages = this.registryMessages.messages
     if (messages.length) {
       ui.render({ added: messages, messages, removed: [] })
     }
   }
   deleteUI(ui: UI) {
+    this.registryUIInit()
     this.registryUI.delete(ui)
   }
+  // Standard Linter
   addLinter(linter: LinterProvider, legacy: boolean = false) {
+    this.registryLintersInit()
     this.registryLinters.addLinter(linter, legacy)
   }
   deleteLinter(linter: LinterProvider) {
+    this.registryLintersInit()
     this.registryLinters.deleteLinter(linter)
+    this.registryMessagesInit()
     this.registryMessages.deleteByLinter(linter)
+  }
+  // Indie Linter
+  addIndie(indie: Object) {
+    this.registryIndieInit()
+    this.registryIndie.register(indie, 2)
+  }
+  addLegacyIndie(indie: Object) {
+    this.registryIndieInit()
+    this.registryIndie.register(indie, 1)
   }
 }
 

--- a/lib/message-registry.js
+++ b/lib/message-registry.js
@@ -15,7 +15,7 @@ type Linter$Message$Map = {
   oldMessages: Array<Message | MessageLegacy>
 }
 
-export default class MessageRegistry {
+class MessageRegistry {
   emitter: Emitter;
   messages: Array<Message | MessageLegacy>;
   messagesMap: Set<Linter$Message$Map>;
@@ -153,3 +153,5 @@ export default class MessageRegistry {
     this.subscriptions.dispose()
   }
 }
+
+module.exports = MessageRegistry

--- a/lib/toggle-view.js
+++ b/lib/toggle-view.js
@@ -5,7 +5,7 @@ import { CompositeDisposable, Emitter, Disposable } from 'atom'
 
 type ToggleAction = 'enable' | 'disable'
 
-export default class ToggleProviders {
+class ToggleProviders {
   action: ToggleAction;
   emitter: Emitter;
   providers: Array<string>;
@@ -76,3 +76,5 @@ export default class ToggleProviders {
     this.subscriptions.dispose()
   }
 }
+
+module.exports = ToggleProviders

--- a/lib/ui-registry.js
+++ b/lib/ui-registry.js
@@ -4,7 +4,7 @@ import { CompositeDisposable } from 'atom'
 import { ui as validateUI } from './validate'
 import type { Linter, UI, MessagesPatch } from './types'
 
-export default class UIRegistry {
+class UIRegistry {
   providers: Set<UI>;
   subscriptions: CompositeDisposable;
 
@@ -44,3 +44,5 @@ export default class UIRegistry {
     this.subscriptions.dispose()
   }
 }
+
+module.exports = UIRegistry

--- a/spec/main-spec.js
+++ b/spec/main-spec.js
@@ -29,6 +29,9 @@ describe('Atom Linter', function() {
       },
       dispose() {},
     }
+    // Force the MessageRegistry to initialze, note that this is handled under
+    // normal usage!
+    atomLinter.registryMessagesInit()
     atomLinter.registryMessages.messages.push(message)
     atomLinter.addUI(uiProvider)
     expect(patchCalled).toBe(1)


### PR DESCRIPTION
Defer as much as possible for later work and/or only when necessary, allowing the package activation time to be majorly reduced.

On my "pristine" profile (`linter`, `linter-ui-default`, `linter-eslint`, `intentions`, `busy-signal`) this brings activation from an average of 111.7 ms down to 8.3 ms. 🎉

Fixes #1026.