### PR TITLE
Allow messages to override the linterName (in v2)

### DIFF
--- a/docs/types/linter-message-v2.md
+++ b/docs/types/linter-message-v2.md
@@ -44,12 +44,13 @@ type Message = {
   description?: string | (() => Promise<string> | string)
   // ^ Markdown long description of the error, accepts callback so you can do
   // http requests etc.
+  linterName?: string,
+  // ^ Optionally override the displayed linter name. Defaults to provider name.
 
   // NOTE: DO NOT SPECIFY THESE IN PROVIDER
   // Automatically added by base linter for UI consumers
   key: string,
   version: 2,
-  linterName: string,
 }
 ```
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -98,7 +98,9 @@ export function normalizeMessages(linterName: string, messages: Array<Message>) 
       }
     }
     message.version = 2
-    message.linterName = linterName
+    if (!message.linterName) {
+      message.linterName = linterName
+    }
     message.key = messageKey(message)
   }
 }

--- a/lib/validate/index.js
+++ b/lib/validate/index.js
@@ -103,6 +103,7 @@ function validateMessages(linterName: string, entries: Array<Message>): boolean 
     let invalidSolution = false
     let invalidReference = false
     let invalidDescription = false
+    let invalidLinterName = false
 
     for (let i = 0, length = entries.length; i < length; ++i) {
       const message = entries[i]
@@ -145,11 +146,15 @@ function validateMessages(linterName: string, entries: Array<Message>): boolean 
       }
       if (!invalidURL && message.url && typeof message.url !== 'string') {
         invalidURL = true
-        messages.push('Message.url must a string')
+        messages.push('Message.url must be a string')
       }
       if (!invalidDescription && message.description && typeof message.description !== 'function' && typeof message.description !== 'string') {
         invalidDescription = true
         messages.push('Message.description must be a function or string')
+      }
+      if (!invalidLinterName && message.linterName && typeof message.linterName !== 'string') {
+        invalidLinterName = true
+        messages.push('Message.linterName must be a string')
       }
     }
   } else {

--- a/spec/helpers-spec.js
+++ b/spec/helpers-spec.js
@@ -174,6 +174,13 @@ describe('Helpers', function() {
       expect(typeof message.linterName).toBe('string')
       expect(message.linterName).toBe('Some Linter')
     })
+    it('preserves linterName if provided', function() {
+      const message = getMessage(false)
+      message.linterName = 'Some Linter 2'
+      Helpers.normalizeMessages('Some Linter', [message])
+      expect(typeof message.linterName).toBe('string')
+      expect(message.linterName).toBe('Some Linter 2')
+    })
     it('converts arrays in location->position to ranges', function() {
       const message = getMessage(false)
       message.location.position = [[0, 0], [0, 0]]

--- a/spec/validate-spec.js
+++ b/spec/validate-spec.js
@@ -555,13 +555,13 @@ describe('Validate', function() {
         excerpt: '',
         severity: 'error',
         url: 5,
-      }], false, 'Message.url must a string')
+      }], false, 'Message.url must be a string')
       validateMessages([{
         location: { file: __filename, position: [[0, 0], [0, 0]] },
         excerpt: '',
         severity: 'error',
         url: {},
-      }], false, 'Message.url must a string')
+      }], false, 'Message.url must be a string')
     })
     it('cries if message.description is present and is invalid', function() {
       validateMessages([{
@@ -613,6 +613,15 @@ describe('Validate', function() {
         description() { },
         severity: 'warning',
       }], true)
+    })
+    it('cries if message.linterName is present and is invalid', function() {
+      validateMessages([{
+        location: { file: __filename, position: [[0, 0], [0, 0]] },
+        excerpt: '',
+        severity: 'error',
+        description: '',
+        linterName: 1,
+      }], false, 'Message.linterName must be a string')
     })
   })
   describe('::messagesLegacy', function() {


### PR DESCRIPTION
This PR allows providers to override the displayed `linterName` on a per-message level.
I added a spec as well as a validator+spec.

Released under CC0.
Closes #1485 