### PR TITLE
Make EditorLinter::onShouldLint spec async

### DIFF
--- a/spec/editor-linter-spec.js
+++ b/spec/editor-linter-spec.js
@@ -1,6 +1,6 @@
 'use babel'
 
-import { it, wait, beforeEach } from 'jasmine-fix'
+import { it, beforeEach } from 'jasmine-fix'
 import EditorLinter from '../lib/editor-linter'
 
 describe('EditorLinter', function() {
@@ -45,23 +45,23 @@ describe('EditorLinter', function() {
   describe('onShouldLint', function() {
     it('is triggered on save', async function() {
       let timesTriggered = 0
-      const editor = new EditorLinter(textEditor)
-      editor.onShouldLint(function() {
-        timesTriggered++
-      })
-      textEditor.save()
-      textEditor.save()
-      textEditor.save()
-      textEditor.save()
+      function waitForShouldLint() {
+        // Register on the textEditor
+        const editorLinter = new EditorLinter(textEditor)
+        // Trigger a (async) save
+        textEditor.save()
+        return new Promise((resolve) => {
+          editorLinter.onShouldLint(() => {
+            timesTriggered++
+            // Dispose of the current registration as it is finished
+            editorLinter.dispose()
+            resolve()
+          })
+        })
+      }
       expect(timesTriggered).toBe(0)
-      await wait(10)
-      expect(timesTriggered).toBe(1)
-      textEditor.save()
-      textEditor.save()
-      textEditor.save()
-      textEditor.save()
-      expect(timesTriggered).toBe(1)
-      await wait(10)
+      await waitForShouldLint()
+      await waitForShouldLint()
       expect(timesTriggered).toBe(2)
     })
   })


### PR DESCRIPTION
Instead of relying on timing and bad counting, make the spec truly async and properly count the number of invocations.