### PR TITLE
Include description in message key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming
+
+* Include `description` in message key (when string rather than promise)
+
 ## 2.2.0
 
 * `linter:debug` overhaul with more debug information

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -76,6 +76,7 @@ export function messageKey(message: Message) {
     `$SEVERITY:${message.severity}`,
     message.icon ? `$ICON:${message.icon}` : '$ICON:null',
     message.url ? `$URL:${message.url}` : '$URL:null',
+    typeof message.description === 'string' ? `$DESCRIPTION:${message.description}` : '$DESCRIPTION:null',
   ].join('')
 }
 


### PR DESCRIPTION
Fix issue where a lint message description changes but the excerpt, range, etc do not change and so the message does not update (https://github.com/nwolverson/atom-ide-purescript/issues/164).

(This also seems to occur if I call `clearMessages` prior to adding the updated message)