### PR TITLE
Exclude non-essential files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,4 @@
 /appveyor.yml export-ignore
 /circle.yml export-ignore
 /package-lock.json export-ignore
-/CHANGELOG.md export-ignore
 /CONTRIBUTING.md export-ignore
-/README.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,7 +6,6 @@
 /.editorconfig export-ignore
 /.eslintignore export-ignore
 /.eslintrc.json export-ignore
-/.eslintrc.json export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,18 @@
 # Auto detect text files and perform LF normalization
 * text eol=lf
+
+/docs export-ignore
+/spec export-ignore
+/.editorconfig export-ignore
+/.eslintignore export-ignore
+/.eslintrc.json export-ignore
+/.eslintrc.json export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/appveyor.yml export-ignore
+/circle.yml export-ignore
+/package-lock.json export-ignore
+/CHANGELOG.md export-ignore
+/CONTRIBUTING.md export-ignore
+/README.md export-ignore


### PR DESCRIPTION
This way the users of this package doesn't have to download non-essential files which aren't necessary for the package to function. Such as files used for development (docs, tests, .travis.yml, etc).

Happy Hacktoberfest!