### PR TITLE
Add button to open Console

### DIFF
--- a/lib/linter-registry.js
+++ b/lib/linter-registry.js
@@ -136,18 +136,19 @@ class LinterRegistry {
           dismissable: true,
           buttons: [
             {
-              text: "Open Console",
+              text: 'Open Console',
               onDidClick: () => {
-                atom.openDevTools();
-                return notification.dismiss();
-              }
-            }, {
-              text: "Cancel",
+                atom.openDevTools()
+                notification.dismiss()
+              },
+            },
+            {
+              text: 'Cancel',
               onDidClick: () => {
-                return notification.dismiss();
-              }
-            }
-          ]
+                notification.dismiss()
+              },
+            },
+          ],
         })
         console.error(`[Linter] Error running ${linter.name}`, error)
       }))

--- a/lib/linter-registry.js
+++ b/lib/linter-registry.js
@@ -131,8 +131,23 @@ class LinterRegistry {
         this.emitter.emit('did-update-messages', { messages, linter, buffer: statusBuffer })
       }, (error) => {
         this.emitter.emit('did-finish-linting', { number, linter, filePath: statusFilePath })
-        atom.notifications.addError(`[Linter] Error running ${linter.name}`, {
-          detail: 'See Console for more info. (Open View -> Developer -> Toggle Developer Tools)',
+        const notification = atom.notifications.addError(`[Linter] Error running ${linter.name}`, {
+          detail: 'See Console for more info.',
+          dismissable: true,
+          buttons: [
+            {
+              text: "Open Console",
+              onDidClick: () => {
+                atom.openDevTools();
+                return notification.dismiss();
+              }
+            }, {
+              text: "Cancel",
+              onDidClick: () => {
+                return notification.dismiss();
+              }
+            }
+          ]
         })
         console.error(`[Linter] Error running ${linter.name}`, error)
       }))


### PR DESCRIPTION
It's probably easier for a user to open the console by the click of the button, rather than providing a description where to find a toggle to do so.