### PR TITLE
Don't wipe messages for file if it is opened multiple times

### DIFF
--- a/lib/editor-linter.js
+++ b/lib/editor-linter.js
@@ -46,7 +46,14 @@ export default class EditorLinter {
     return this.emitter.on('did-destroy', callback)
   }
   dispose() {
-    this.emitter.emit('did-destroy')
+    let thereIsAnotherEditorForTheSameFile = false
+    for (const editor of atom.textEditors.editors) {
+      if (this.editor.getTitle() === editor.getTitle()) {
+        thereIsAnotherEditorForTheSameFile = true
+      }
+    }
+
+    this.emitter.emit('did-destroy', thereIsAnotherEditorForTheSameFile)
     this.subscriptions.dispose()
     this.emitter.dispose()
   }

--- a/lib/editor-linter.js
+++ b/lib/editor-linter.js
@@ -48,7 +48,7 @@ export default class EditorLinter {
   dispose() {
     let thereIsAnotherEditorForTheSameFile = false
     for (const editor of atom.textEditors.editors) {
-      if (this.editor.getTitle() === editor.getTitle()) {
+      if (this.editor.getBuffer() === editor.getBuffer()) {
         thereIsAnotherEditorForTheSameFile = true
       }
     }

--- a/lib/main.js
+++ b/lib/main.js
@@ -127,7 +127,9 @@ class Linter {
       editorLinter.onDidDestroy((thereIsAnotherEditorForTheSameFile) => {
         this.registryMessagesInit()
 
-        if (!thereIsAnotherEditorForTheSameFile) this.registryMessages.deleteByBuffer(editorLinter.getEditor().getBuffer())
+        if (!thereIsAnotherEditorForTheSameFile) {
+          this.registryMessages.deleteByBuffer(editorLinter.getEditor().getBuffer())
+        }
       })
     })
     this.registryEditors.activate()

--- a/lib/main.js
+++ b/lib/main.js
@@ -124,9 +124,10 @@ class Linter {
         this.registryLintersInit()
         this.registryLinters.lint({ onChange, editor: editorLinter.getEditor() })
       })
-      editorLinter.onDidDestroy(() => {
+      editorLinter.onDidDestroy((thereIsAnotherEditorForTheSameFile) => {
         this.registryMessagesInit()
-        this.registryMessages.deleteByBuffer(editorLinter.getEditor().getBuffer())
+
+        if (!thereIsAnotherEditorForTheSameFile) this.registryMessages.deleteByBuffer(editorLinter.getEditor().getBuffer())
       })
     })
     this.registryEditors.activate()

--- a/spec/editor-linter-spec.js
+++ b/spec/editor-linter-spec.js
@@ -40,6 +40,15 @@ describe('EditorLinter', function() {
       textEditor.destroy()
       expect(triggered).toBe(true)
     })
+    it('signals that there is another editor for the same file', async function() {
+      atom.workspace.getActivePane().splitLeft({ copyActiveItem: true, items: [] })
+      let editor = new EditorLinter(textEditor)
+      textEditor = atom.workspace.getActiveTextEditor()
+      editor = new EditorLinter(textEditor)
+      spyOn(editor.emitter, 'emit')
+      textEditor.destroy()
+      expect(editor.emitter.emit).toHaveBeenCalledWith('did-destroy', true)
+    })
   })
 
   describe('onShouldLint', function() {


### PR DESCRIPTION
This addresses the issue described in #1510 

## Preview
This first gif shows the current behaviour, the two JS editors are for the same file. Notice how the linting errors in the bottom now longer show up when focusing the editor at the top.
![current behaviour](https://user-images.githubusercontent.com/3742559/46891656-3628bb00-ce73-11e8-8a3d-edec97140d44.gif)

This second gif shows the new behaviour, the two JS editors are for the same file. Notice how the linting errors in the bottom still show up when focusing the editor at the top.
![new bahaviour](https://user-images.githubusercontent.com/3742559/46891547-e4803080-ce72-11e8-8431-e1131218be10.gif)

## Alternative implementations
I'm not sure if the implementation I chose is desired. My reasoning behind it is that the information (`thereIsAnotherEditorForTheSameFile`) might be useful in other scenarios as well. Alternatively the check for other buffers can be performed in the [deleteByBuffer](https://github.com/steelbrain/linter/blob/1f9efea649c43ab50097d6ddc0d1e9685ee28413/lib/message-registry.js#L136) in the `MessageRegistry`.

Also, let me know if the variable name `thereIsAnotherEditorForTheSameFile` is too much 😛 

## Limitations ⚠️
This PR does not fix everything noted in or related to #1510. For example, in the second gif you can see that the lint-gutter of the editor at the top stops working when the editor at the bottom is closed.