### PR TITLE
Handle editors with no path in debug call

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -26,7 +26,11 @@ export function getEditorCursorScopes(textEditor: TextEditor): Array<string> {
 }
 
 let minimatch
-export function isPathIgnored(filePath: string, ignoredGlob: string, ignoredVCS: boolean): boolean {
+export function isPathIgnored(filePath: ?string, ignoredGlob: string, ignoredVCS: boolean): boolean {
+  if (!filePath) {
+    return true
+  }
+
   if (ignoredVCS) {
     let repository = null
     const projectPaths = atom.project.getPaths()

--- a/lib/linter-registry.js
+++ b/lib/linter-registry.js
@@ -85,8 +85,8 @@ class LinterRegistry {
 
     if (
       (onChange && !this.lintOnChange) || // Lint-on-change mismatch
-      !filePath || // Not saved anywhere yet
-      Helpers.isPathIgnored(editor.getPath(), this.ignoreGlob, this.ignoreVCS) || // Ignored by VCS or Glob
+      // Ignored by VCS, Glob, or simply not saved anywhere yet
+      Helpers.isPathIgnored(editor.getPath(), this.ignoreGlob, this.ignoreVCS) ||
       (!this.lintPreviewTabs && atom.workspace.getActivePane().getPendingItem() === editor) // Ignore Preview tabs
     ) {
       return false

--- a/spec/helpers-spec.js
+++ b/spec/helpers-spec.js
@@ -136,6 +136,11 @@ describe('Helpers', function() {
         atom.workspace.destroyActivePane()
       }
     })
+    it('returns true if no path is given', function() {
+      expect(isPathIgnored(undefined)).toBe(true)
+      expect(isPathIgnored(null)).toBe(true)
+      expect(isPathIgnored('')).toBe(true)
+    })
   })
   describe('subscriptiveObserve', function() {
     it('activates synchronously', function() {


### PR DESCRIPTION
Fix calls to `Linter: Debug` on editors that don't have a path (no saved file), returning that they are ignored.