### PR TITLE
chore: mention linter-ui-default dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ $ apm install linter
 
 Or you can install from Settings view by searching for `Base Linter`, (this package might not show up when searching for `Linter`).
 
+If nothing seems to happen after installing the linter package and at least one language package, you may have to install the `linter-ui-default package`.  This package handles displaying results and errors in the Atom UI.
+
 #### API Documentation
 
 Please navigate to [steelbrain.me/linter](http://steelbrain.me/linter/) for Linter v2 documentation.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ apm install linter
 
 Or you can install from Settings view by searching for `Base Linter`, (this package might not show up when searching for `Linter`).
 
-If nothing seems to happen after installing the linter package and at least one language package, you may have to install the `linter-ui-default package`.  This package handles displaying results and errors in the Atom UI.
+Linter automatically installs `linter-ui-default`, which is required for the functionality of this package.
 
 #### API Documentation
 


### PR DESCRIPTION
Add instructions in the README to prompt user to install the linter-ui-default package if it's not auto-installed.

As a newbie Atom user, I went ahead and installed the linter and code package like all the docs and guides stated.  It took longer than I'd like to admit to find closed Issue #1712 which indicated that the UI package needed to be installed too.

Hope this little addition helps someone else down the line.  Of course, feel free to tweak as you see fit - or let me know if this is something that shouldn't have arisen.  Thanks!