### PR TITLE
docs: Fix a few typos

### DIFF
--- a/spec/main-spec.js
+++ b/spec/main-spec.js
@@ -30,7 +30,7 @@ describe('Atom Linter', function () {
       },
       dispose() {},
     }
-    // Force the MessageRegistry to initialze, note that this is handled under
+    // Force the MessageRegistry to initialize, note that this is handled under
     // normal usage!
     atomLinter.registryMessagesInit()
     atomLinter.registryMessages.messages.push(message)

--- a/spec/message-registry-spec.js
+++ b/spec/message-registry-spec.js
@@ -333,7 +333,7 @@ describe('Message Registry', function () {
     })
 
     // This functionality was removed in https://github.com/steelbrain/linter/pull/1706 due to performance reasons
-    //   it('notices changes on last messages instead of relying on their keys and invaildates them', function() {
+    //   it('notices changes on last messages instead of relying on their keys and invalidates them', function() {
     //     let called = 0
     //
     //     const linter: Object = { name: 'any' }


### PR DESCRIPTION
There are small typos in:
- spec/main-spec.js
- spec/message-registry-spec.js

Fixes:
- Should read `invalidates` rather than `invaildates`.
- Should read `initialize` rather than `initialze`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md